### PR TITLE
Add dependency installation scripts for Linux

### DIFF
--- a/scripts/install_deps_alpine.sh
+++ b/scripts/install_deps_alpine.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# Install dependencies for discourse-link-archiver on Alpine Linux
+set -eu
+
+echo "Installing dependencies for discourse-link-archiver (Alpine Linux)..."
+
+# Install system packages
+apk add --no-cache \
+    build-base \
+    pkgconfig \
+    openssl-dev \
+    sqlite-dev \
+    ffmpeg \
+    zstd \
+    python3 \
+    py3-pip \
+    curl \
+    rust \
+    cargo
+
+# Install yt-dlp and gallery-dl via pip
+pip3 install --break-system-packages yt-dlp gallery-dl 2>/dev/null || \
+    pip3 install yt-dlp gallery-dl
+
+echo ""
+echo "Dependencies installed successfully!"
+echo ""
+echo "Installed versions:"
+echo "  rustc: $(rustc --version)"
+echo "  ffmpeg: $(ffmpeg -version | head -1)"
+echo "  yt-dlp: $(yt-dlp --version)"
+echo "  gallery-dl: $(gallery-dl --version)"
+echo "  zstd: $(zstd --version | head -1)"

--- a/scripts/install_deps_arch.sh
+++ b/scripts/install_deps_arch.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Install dependencies for discourse-link-archiver on Arch Linux
+set -euo pipefail
+
+echo "Installing dependencies for discourse-link-archiver (Arch Linux)..."
+
+# Install system packages
+sudo pacman -Syu --noconfirm \
+    base-devel \
+    pkgconf \
+    openssl \
+    sqlite \
+    ffmpeg \
+    zstd \
+    python \
+    python-pip \
+    yt-dlp \
+    rust
+
+# Install gallery-dl (from AUR or pip)
+if command -v yay &> /dev/null; then
+    yay -S --noconfirm gallery-dl
+elif command -v paru &> /dev/null; then
+    paru -S --noconfirm gallery-dl
+else
+    echo "Installing gallery-dl via pip (no AUR helper found)..."
+    pip install --user gallery-dl
+fi
+
+echo ""
+echo "Dependencies installed successfully!"
+echo ""
+echo "Installed versions:"
+echo "  rustc: $(rustc --version)"
+echo "  ffmpeg: $(ffmpeg -version | head -1)"
+echo "  yt-dlp: $(yt-dlp --version)"
+echo "  gallery-dl: $(gallery-dl --version 2>/dev/null || echo 'not in PATH - check ~/.local/bin')"
+echo "  zstd: $(zstd --version | head -1)"

--- a/scripts/install_deps_fedora.sh
+++ b/scripts/install_deps_fedora.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Install dependencies for discourse-link-archiver on Fedora/RHEL/CentOS
+set -euo pipefail
+
+echo "Installing dependencies for discourse-link-archiver (Fedora/RHEL)..."
+
+# Install system packages
+sudo dnf install -y \
+    gcc \
+    make \
+    pkgconfig \
+    openssl-devel \
+    sqlite-devel \
+    ffmpeg-free \
+    zstd \
+    python3 \
+    python3-pip
+
+# On RHEL/CentOS, ffmpeg may need RPM Fusion
+if ! command -v ffmpeg &> /dev/null; then
+    echo "Note: ffmpeg not found. On RHEL/CentOS, enable RPM Fusion:"
+    echo "  sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-\$(rpm -E %fedora).noarch.rpm"
+    echo "  sudo dnf install ffmpeg"
+fi
+
+# Install yt-dlp and gallery-dl via pip
+pip3 install --user yt-dlp gallery-dl
+
+# Install Rust if not present
+if ! command -v rustc &> /dev/null; then
+    echo "Installing Rust..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    source "$HOME/.cargo/env"
+fi
+
+echo ""
+echo "Dependencies installed successfully!"
+echo ""
+echo "Installed versions:"
+echo "  rustc: $(rustc --version 2>/dev/null || echo 'not in PATH - run: source ~/.cargo/env')"
+echo "  ffmpeg: $(ffmpeg -version 2>/dev/null | head -1 || echo 'not found - see note above')"
+echo "  yt-dlp: $(yt-dlp --version 2>/dev/null || echo 'not in PATH - check ~/.local/bin')"
+echo "  gallery-dl: $(gallery-dl --version 2>/dev/null || echo 'not in PATH - check ~/.local/bin')"
+echo "  zstd: $(zstd --version | head -1)"
+echo ""
+echo "You may need to restart your shell or run: source ~/.cargo/env"
+echo "Ensure ~/.local/bin is in your PATH for yt-dlp and gallery-dl"

--- a/scripts/install_deps_opensuse.sh
+++ b/scripts/install_deps_opensuse.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Install dependencies for discourse-link-archiver on openSUSE
+set -euo pipefail
+
+echo "Installing dependencies for discourse-link-archiver (openSUSE)..."
+
+# Install system packages
+sudo zypper install -y \
+    gcc \
+    make \
+    pkg-config \
+    libopenssl-devel \
+    sqlite3-devel \
+    ffmpeg \
+    zstd \
+    python3 \
+    python3-pip
+
+# Install yt-dlp and gallery-dl via pip
+pip3 install --user yt-dlp gallery-dl
+
+# Install Rust if not present
+if ! command -v rustc &> /dev/null; then
+    echo "Installing Rust..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    source "$HOME/.cargo/env"
+fi
+
+echo ""
+echo "Dependencies installed successfully!"
+echo ""
+echo "Installed versions:"
+echo "  rustc: $(rustc --version 2>/dev/null || echo 'not in PATH - run: source ~/.cargo/env')"
+echo "  ffmpeg: $(ffmpeg -version | head -1)"
+echo "  yt-dlp: $(yt-dlp --version 2>/dev/null || echo 'not in PATH - check ~/.local/bin')"
+echo "  gallery-dl: $(gallery-dl --version 2>/dev/null || echo 'not in PATH - check ~/.local/bin')"
+echo "  zstd: $(zstd --version | head -1)"
+echo ""
+echo "You may need to restart your shell or run: source ~/.cargo/env"
+echo "Ensure ~/.local/bin is in your PATH for yt-dlp and gallery-dl"

--- a/scripts/install_deps_ubuntu.sh
+++ b/scripts/install_deps_ubuntu.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Install dependencies for discourse-link-archiver on Ubuntu/Debian
+set -euo pipefail
+
+echo "Installing dependencies for discourse-link-archiver (Ubuntu/Debian)..."
+
+# Update package lists
+sudo apt-get update
+
+# Install system packages
+sudo apt-get install -y \
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    libsqlite3-dev \
+    ffmpeg \
+    zstd \
+    python3 \
+    python3-pip \
+    curl
+
+# Install yt-dlp (prefer pipx or pip for latest version)
+if command -v pipx &> /dev/null; then
+    pipx install yt-dlp
+    pipx install gallery-dl
+elif command -v pip3 &> /dev/null; then
+    pip3 install --user yt-dlp gallery-dl
+else
+    echo "Warning: pip3 not found, installing yt-dlp from apt (may be outdated)"
+    sudo apt-get install -y yt-dlp
+fi
+
+# Install Rust if not present
+if ! command -v rustc &> /dev/null; then
+    echo "Installing Rust..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    source "$HOME/.cargo/env"
+fi
+
+echo ""
+echo "Dependencies installed successfully!"
+echo ""
+echo "Installed versions:"
+echo "  rustc: $(rustc --version 2>/dev/null || echo 'not in PATH - run: source ~/.cargo/env')"
+echo "  ffmpeg: $(ffmpeg -version 2>/dev/null | head -1 || echo 'not found')"
+echo "  yt-dlp: $(yt-dlp --version 2>/dev/null || echo 'not in PATH')"
+echo "  gallery-dl: $(gallery-dl --version 2>/dev/null || echo 'not in PATH')"
+echo "  zstd: $(zstd --version 2>/dev/null | head -1 || echo 'not found')"
+echo ""
+echo "You may need to restart your shell or run: source ~/.cargo/env"


### PR DESCRIPTION
Add scripts/install_deps_*.sh for common Linux distributions:
- Ubuntu/Debian: apt-based installation with pip fallback
- Arch Linux: pacman with AUR helper support
- Fedora/RHEL: dnf-based with RPM Fusion notes for ffmpeg
- Alpine: apk-based for container environments
- openSUSE: zypper-based installation

All scripts install: Rust, ffmpeg, yt-dlp, gallery-dl, zstd, and build dependencies (sqlite-dev, openssl-dev, pkg-config).