### PR TITLE
Fix Docker build dependency download issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.83-bookworm AS builder
+FROM rust:1.85-bookworm AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
The `home` crate v0.5.12 requires Rust edition 2024, which is only supported in Rust 1.85+. The previous image used Rust 1.83 which caused the build to fail with "feature `edition2024` is required".