### PR TITLE
Add Bluesky and Streamable handlers

### DIFF
--- a/MAIN_TASKS.md
+++ b/MAIN_TASKS.md
@@ -257,6 +257,92 @@ Legend: `[ ]` pending, `[x]` complete, `[-]` skipped/blocked
 
 ---
 
+## Phase 12: High-Value Feature Additions
+
+### New Site Handlers
+- [x] Bluesky handler
+  - [x] URL patterns for bsky.app, bsky.social
+  - [x] Resolve handle to DID via AT Protocol
+  - [x] Fetch post via getPostThread API
+  - [x] Download embedded images from CDN
+  - [x] Store post JSON and media
+  - [x] Write unit tests
+- [x] Streamable handler
+  - [x] URL patterns for streamable.com
+  - [x] Archive via yt-dlp (already supported)
+  - [x] Write unit tests
+
+### Archive.today Integration
+- [x] Add archive.today client module
+- [x] Submit URLs to archive.today/submit/
+- [x] Rate limit submissions (3/minute)
+- [x] Store archive.today URL in database
+- [x] Add `archive_today_url` field to archives table
+- [x] Handle submission failures gracefully
+- [x] Add configuration (ARCHIVE_TODAY_ENABLED)
+
+### RSS Feed of Archives
+- [x] Add RSS 2.0 feed route at /feed.rss
+- [x] Add Atom 1.0 feed route at /feed.atom
+- [x] Include last 50 archives by default
+- [ ] Add optional site/type query filters
+- [x] Write unit tests for feed generation
+
+### Content Deduplication
+- [ ] Add image_hasher dependency
+- [ ] Add perceptual_hash column to archive_artifacts
+- [ ] Compute pHash for images during archiving
+- [ ] Check for near-duplicates before downloading
+- [ ] Link to existing archive if duplicate found
+- [ ] Add similarity threshold configuration
+- [ ] Write unit tests for hash comparison
+
+### Screenshot Capture
+- [ ] Add chromiumoxide or headless_chrome dependency
+- [ ] Create screenshot capture module
+- [ ] Configure viewport dimensions
+- [ ] Capture full-page screenshots as PNG
+- [ ] Store in S3 render/ directory
+- [ ] Add configuration options
+- [ ] Handle browser startup/cleanup
+- [ ] Write unit tests
+
+### PDF Generation
+- [ ] Use browser print-to-PDF capability
+- [ ] Configure paper size settings
+- [ ] Generate PDF for article content
+- [ ] Store in S3 render/ directory
+- [ ] Add configuration options
+- [ ] Write unit tests
+
+### Dark Mode for Web UI
+- [x] Add CSS dark mode variables
+- [x] Implement prefers-color-scheme detection
+- [x] Add manual toggle switch in header
+- [x] Store preference in localStorage
+- [x] Update PicoCSS to dark theme
+- [x] Test all pages in dark mode
+
+### Archive Comparison
+- [ ] Add similar crate for text diffing
+- [ ] Create comparison route /compare/{id1}/{id2}
+- [ ] Implement side-by-side diff view
+- [ ] Highlight additions/deletions
+- [ ] Show timestamp comparison
+- [ ] Create diff template
+
+### Bulk Export
+- [ ] Create export route /export/{site}
+- [ ] Generate ZIP archive of domain content
+- [ ] Exclude large video files (>50MB)
+- [ ] Include metadata.json manifest
+- [ ] Add rate limiting (1/hour per IP)
+- [ ] Add max export size limit
+- [ ] Stream ZIP generation to avoid memory issues
+- [ ] Write unit tests
+
+---
+
 ## Discovered Tasks
 
 Add new tasks here as they are discovered during development:

--- a/src/archive_today/mod.rs
+++ b/src/archive_today/mod.rs
@@ -1,0 +1,293 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use reqwest::Client;
+use tokio::sync::Semaphore;
+use tokio::time::sleep;
+use tracing::{debug, info, warn};
+
+/// Rate-limited Archive.today client.
+pub struct ArchiveTodayClient {
+    client: Client,
+    /// Semaphore for rate limiting (permits per minute).
+    rate_limiter: Arc<Semaphore>,
+    /// Interval between permit releases.
+    permit_interval: Duration,
+}
+
+impl ArchiveTodayClient {
+    /// Create a new Archive.today client with rate limiting.
+    ///
+    /// # Arguments
+    ///
+    /// * `rate_limit_per_min` - Maximum submissions per minute (default 3).
+    #[must_use]
+    pub fn new(rate_limit_per_min: u32) -> Self {
+        let rate_limit = rate_limit_per_min.max(1) as usize;
+        let permit_interval = Duration::from_secs(60) / rate_limit as u32;
+
+        let client = Client::builder()
+            .timeout(Duration::from_secs(60))
+            .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+            .redirect(reqwest::redirect::Policy::limited(10))
+            .build()
+            .expect("Failed to create HTTP client");
+
+        let rate_limiter = Arc::new(Semaphore::new(rate_limit));
+
+        // Start background task to release permits over time
+        let limiter = rate_limiter.clone();
+        let interval = permit_interval;
+        tokio::spawn(async move {
+            loop {
+                sleep(interval).await;
+                // Add permit back if below limit
+                if limiter.available_permits() < rate_limit {
+                    limiter.add_permits(1);
+                }
+            }
+        });
+
+        Self {
+            client,
+            rate_limiter,
+            permit_interval,
+        }
+    }
+
+    /// Submit a URL to Archive.today for archiving.
+    ///
+    /// Returns the archive URL if successful.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the submission fails or times out.
+    pub async fn submit(&self, url: &str) -> Result<Option<String>> {
+        // Acquire rate limit permit
+        let _permit = self
+            .rate_limiter
+            .acquire()
+            .await
+            .context("Rate limiter closed")?;
+
+        // Brief pause to respect rate limiting
+        sleep(Duration::from_millis(500)).await;
+
+        debug!(url = %url, "Submitting URL to Archive.today");
+
+        // Archive.today uses form submission
+        // First, check if the URL is already archived
+        if let Some(existing) = self.check_existing(url).await? {
+            info!(url = %url, archive = %existing, "URL already archived on Archive.today");
+            return Ok(Some(existing));
+        }
+
+        // Submit the URL for archiving
+        // Archive.today's submission endpoint
+        let submit_url = "https://archive.today/submit/";
+
+        let form = [("url", url)];
+
+        let response = self
+            .client
+            .post(submit_url)
+            .form(&form)
+            .send()
+            .await
+            .context("Failed to submit to Archive.today")?;
+
+        let status = response.status();
+        let final_url = response.url().to_string();
+
+        // Archive.today typically redirects to the archived page
+        if status.is_success() || status.is_redirection() {
+            // Read the response body once
+            let body = response.text().await.unwrap_or_default();
+
+            // Check if we got redirected to an archive page
+            if final_url.contains("archive.today/") || final_url.contains("archive.ph/") {
+                // Look for the canonical archive URL in the response
+                if let Some(archive_url) = extract_archive_url(&body) {
+                    info!(url = %url, archive = %archive_url, "Archive.today snapshot created");
+                    return Ok(Some(archive_url));
+                }
+
+                // If we're on an archive.today URL, return it
+                if final_url.starts_with("https://archive.today/")
+                    || final_url.starts_with("https://archive.ph/")
+                    || final_url.starts_with("https://archive.is/")
+                {
+                    info!(url = %url, archive = %final_url, "Archive.today snapshot created");
+                    return Ok(Some(final_url));
+                }
+            }
+
+            // Try to get archive URL from response body
+            if let Some(archive_url) = extract_archive_url(&body) {
+                info!(url = %url, archive = %archive_url, "Archive.today snapshot created");
+                return Ok(Some(archive_url));
+            }
+
+            // Return generic search URL if we can't determine exact archive
+            let search_url = format!("https://archive.today/{}", urlencoding::encode(url));
+            info!(url = %url, "Archive.today submission accepted");
+            Ok(Some(search_url))
+        } else if status.as_u16() == 429 {
+            warn!(url = %url, "Archive.today rate limited, will retry later");
+            // Wait extra time on rate limit
+            sleep(self.permit_interval * 3).await;
+            Ok(None)
+        } else {
+            warn!(url = %url, status = %status, "Archive.today submission failed");
+            Ok(None)
+        }
+    }
+
+    /// Check if a URL has been archived on Archive.today.
+    ///
+    /// Returns the most recent archive URL if available.
+    pub async fn check_existing(&self, url: &str) -> Result<Option<String>> {
+        let check_url = format!("https://archive.today/{}", urlencoding::encode(url));
+
+        let response = self
+            .client
+            .get(&check_url)
+            .send()
+            .await
+            .context("Failed to check Archive.today")?;
+
+        if !response.status().is_success() {
+            return Ok(None);
+        }
+
+        let final_url = response.url().to_string();
+
+        // If we got redirected to an actual archive, return it
+        // Archive URLs typically look like: https://archive.today/XXXXX
+        if is_archive_url(&final_url) {
+            return Ok(Some(final_url));
+        }
+
+        // Check the response body for archive links
+        let body = response.text().await.unwrap_or_default();
+        if let Some(archive_url) = extract_archive_url(&body) {
+            return Ok(Some(archive_url));
+        }
+
+        Ok(None)
+    }
+}
+
+/// Check if a URL is an Archive.today archive URL.
+fn is_archive_url(url: &str) -> bool {
+    // Known non-archive paths that should not be matched
+    const EXCLUDED_PATHS: [&str; 5] = ["submit", "search", "about", "faq", "timegate"];
+
+    let patterns = [
+        "archive.today/",
+        "archive.ph/",
+        "archive.is/",
+        "archive.li/",
+        "archive.vn/",
+        "archive.md/",
+    ];
+
+    for pattern in &patterns {
+        if url.contains(pattern) {
+            // Check that it's not just a search/submit page
+            if let Some(after_domain) = url.split(pattern).nth(1) {
+                // Archive URLs have a short hash after the domain
+                let first_part = after_domain.split('/').next().unwrap_or("");
+                // Exclude known non-archive paths
+                let is_excluded = EXCLUDED_PATHS
+                    .iter()
+                    .any(|&p| first_part.eq_ignore_ascii_case(p));
+                if !is_excluded
+                    && first_part.len() >= 5
+                    && first_part.len() <= 10
+                    && first_part.chars().all(|c| c.is_alphanumeric())
+                {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+/// Extract archive URL from HTML response body.
+fn extract_archive_url(body: &str) -> Option<String> {
+    // Look for canonical link
+    if let Some(start) = body.find("rel=\"canonical\" href=\"") {
+        let after_start = &body[start + 22..];
+        if let Some(end) = after_start.find('"') {
+            let url = &after_start[..end];
+            if is_archive_url(url) {
+                return Some(url.to_string());
+            }
+        }
+    }
+
+    // Look for og:url meta tag
+    if let Some(start) = body.find("property=\"og:url\" content=\"") {
+        let after_start = &body[start + 27..];
+        if let Some(end) = after_start.find('"') {
+            let url = &after_start[..end];
+            if is_archive_url(url) {
+                return Some(url.to_string());
+            }
+        }
+    }
+
+    // Look for archive links in the body
+    for pattern in &[
+        "https://archive.today/",
+        "https://archive.ph/",
+        "https://archive.is/",
+    ] {
+        if let Some(start) = body.find(pattern) {
+            let after_start = &body[start..];
+            // Find the end of the URL (quote, space, or angle bracket)
+            let end = after_start
+                .chars()
+                .position(|c| c == '"' || c == '\'' || c == '<' || c == '>' || c.is_whitespace())
+                .unwrap_or(after_start.len());
+
+            let url = &after_start[..end];
+            if is_archive_url(url) {
+                return Some(url.to_string());
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_archive_url() {
+        assert!(is_archive_url("https://archive.today/AbCd1"));
+        assert!(is_archive_url("https://archive.ph/Xy9Zw"));
+        assert!(is_archive_url("https://archive.is/12345"));
+        assert!(!is_archive_url("https://archive.today/submit/"));
+        assert!(!is_archive_url("https://example.com/archive.today/"));
+        assert!(!is_archive_url("https://archive.today/")); // Just root URL
+    }
+
+    #[test]
+    fn test_extract_archive_url() {
+        let html = r#"<link rel="canonical" href="https://archive.today/AbCd1">"#;
+        assert_eq!(
+            extract_archive_url(html),
+            Some("https://archive.today/AbCd1".to_string())
+        );
+
+        let html_no_match = r#"<link rel="canonical" href="https://example.com">"#;
+        assert_eq!(extract_archive_url(html_no_match), None);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,6 +56,10 @@ pub struct Config {
     pub wayback_enabled: bool,
     pub wayback_rate_limit_per_min: u32,
 
+    // Archive.today
+    pub archive_today_enabled: bool,
+    pub archive_today_rate_limit_per_min: u32,
+
     // Backup
     pub backup_enabled: bool,
     pub backup_interval_hours: u64,
@@ -133,6 +137,10 @@ impl Config {
             // Wayback Machine
             wayback_enabled: parse_env_bool("WAYBACK_ENABLED", true)?,
             wayback_rate_limit_per_min: parse_env_u32("WAYBACK_RATE_LIMIT_PER_MIN", 5)?,
+
+            // Archive.today
+            archive_today_enabled: parse_env_bool("ARCHIVE_TODAY_ENABLED", false)?,
+            archive_today_rate_limit_per_min: parse_env_u32("ARCHIVE_TODAY_RATE_LIMIT_PER_MIN", 3)?,
 
             // Backup
             backup_enabled: parse_env_bool("BACKUP_ENABLED", true)?,

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -113,6 +113,7 @@ pub struct Archive {
     pub s3_key_thumb: Option<String>,
     pub s3_keys_extra: Option<String>,
     pub wayback_url: Option<String>,
+    pub archive_today_url: Option<String>,
     pub ipfs_cid: Option<String>,
     pub error_message: Option<String>,
     pub retry_count: i32,

--- a/src/handlers/bluesky.rs
+++ b/src/handlers/bluesky.rs
@@ -1,0 +1,449 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use super::traits::{ArchiveResult, SiteHandler};
+
+static PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+    vec![
+        Regex::new(r"^https?://bsky\.app/profile/[^/]+/post/[a-zA-Z0-9]+").unwrap(),
+        Regex::new(r"^https?://bsky\.social/profile/[^/]+/post/[a-zA-Z0-9]+").unwrap(),
+    ]
+});
+
+// Regex to extract handle and post ID from URL
+static URL_PARSER: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^https?://bsky\.(app|social)/profile/([^/]+)/post/([a-zA-Z0-9]+)").unwrap()
+});
+
+const BSKY_API_BASE: &str = "https://public.api.bsky.app/xrpc";
+
+pub struct BlueskyHandler {
+    client: reqwest::Client,
+}
+
+impl BlueskyHandler {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::Client::builder()
+                .user_agent("discourse-link-archiver/1.0")
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("Failed to build HTTP client"),
+        }
+    }
+}
+
+impl Default for BlueskyHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Response from resolveHandle API
+#[derive(Debug, Deserialize)]
+struct ResolveHandleResponse {
+    did: String,
+}
+
+/// Response from getPostThread API
+#[derive(Debug, Deserialize)]
+struct PostThreadResponse {
+    thread: ThreadPost,
+}
+
+#[derive(Debug, Deserialize)]
+struct ThreadPost {
+    post: Post,
+}
+
+#[derive(Debug, Deserialize)]
+struct Post {
+    uri: String,
+    cid: String,
+    author: Author,
+    record: PostRecord,
+    #[serde(default)]
+    embed: Option<Embed>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Author {
+    did: String,
+    handle: String,
+    #[serde(rename = "displayName")]
+    display_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PostRecord {
+    text: String,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "$type")]
+enum Embed {
+    #[serde(rename = "app.bsky.embed.images#view")]
+    Images { images: Vec<EmbedImage> },
+    #[serde(rename = "app.bsky.embed.external#view")]
+    External { external: ExternalEmbed },
+    #[serde(rename = "app.bsky.embed.record#view")]
+    Record {
+        #[allow(dead_code)]
+        record: serde_json::Value,
+    },
+    #[serde(rename = "app.bsky.embed.recordWithMedia#view")]
+    RecordWithMedia {
+        #[allow(dead_code)]
+        media: serde_json::Value,
+    },
+    #[serde(rename = "app.bsky.embed.video#view")]
+    Video(VideoEmbed),
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Deserialize)]
+struct EmbedImage {
+    thumb: String,
+    fullsize: String,
+    #[allow(dead_code)]
+    alt: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExternalEmbed {
+    uri: String,
+    title: String,
+    description: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct VideoEmbed {
+    thumbnail: Option<String>,
+    #[allow(dead_code)]
+    playlist: Option<String>,
+}
+
+/// Metadata saved to JSON file
+#[derive(Debug, Serialize)]
+struct BlueskyMetadata {
+    uri: String,
+    cid: String,
+    author_did: String,
+    author_handle: String,
+    author_display_name: Option<String>,
+    text: String,
+    created_at: String,
+    embed_type: Option<String>,
+    image_urls: Vec<String>,
+    external_url: Option<String>,
+}
+
+impl BlueskyHandler {
+    /// Parse handle and post ID from a Bluesky URL
+    fn parse_url(url: &str) -> Option<(String, String)> {
+        URL_PARSER.captures(url).map(|caps| {
+            let handle = caps.get(2).unwrap().as_str().to_string();
+            let post_id = caps.get(3).unwrap().as_str().to_string();
+            (handle, post_id)
+        })
+    }
+
+    /// Resolve a handle to a DID
+    async fn resolve_handle(&self, handle: &str) -> Result<String> {
+        let url = format!(
+            "{}/com.atproto.identity.resolveHandle?handle={}",
+            BSKY_API_BASE, handle
+        );
+
+        let response: ResolveHandleResponse = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context("Failed to resolve Bluesky handle")?
+            .error_for_status()
+            .context("Handle resolution returned error")?
+            .json()
+            .await
+            .context("Failed to parse handle resolution response")?;
+
+        Ok(response.did)
+    }
+
+    /// Fetch a post thread by AT URI
+    async fn get_post(&self, did: &str, post_id: &str) -> Result<Post> {
+        let at_uri = format!("at://{}/app.bsky.feed.post/{}", did, post_id);
+        let url = format!(
+            "{}/app.bsky.feed.getPostThread?uri={}",
+            BSKY_API_BASE,
+            urlencoding::encode(&at_uri)
+        );
+
+        let response: PostThreadResponse = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context("Failed to fetch Bluesky post")?
+            .error_for_status()
+            .context("Post fetch returned error")?
+            .json()
+            .await
+            .context("Failed to parse post response")?;
+
+        Ok(response.thread.post)
+    }
+
+    /// Download an image from Bluesky CDN
+    async fn download_image(&self, url: &str, work_dir: &Path, index: usize) -> Result<String> {
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .context("Failed to download image")?
+            .error_for_status()
+            .context("Image download returned error")?;
+
+        // Determine extension from content-type or URL
+        let ext = response
+            .headers()
+            .get("content-type")
+            .and_then(|ct| ct.to_str().ok())
+            .map(|ct| match ct {
+                "image/jpeg" => "jpg",
+                "image/png" => "png",
+                "image/gif" => "gif",
+                "image/webp" => "webp",
+                _ => "jpg",
+            })
+            .unwrap_or("jpg");
+
+        let filename = format!("image_{}.{}", index, ext);
+        let file_path = work_dir.join(&filename);
+
+        let bytes = response
+            .bytes()
+            .await
+            .context("Failed to read image bytes")?;
+        tokio::fs::write(&file_path, &bytes)
+            .await
+            .context("Failed to write image file")?;
+
+        Ok(filename)
+    }
+}
+
+#[async_trait]
+impl SiteHandler for BlueskyHandler {
+    fn site_id(&self) -> &'static str {
+        "bluesky"
+    }
+
+    fn url_patterns(&self) -> &[Regex] {
+        &PATTERNS
+    }
+
+    fn priority(&self) -> i32 {
+        100
+    }
+
+    fn normalize_url(&self, url: &str) -> String {
+        // Normalize to bsky.app format
+        url.replace("bsky.social", "bsky.app")
+    }
+
+    async fn archive(
+        &self,
+        url: &str,
+        work_dir: &Path,
+        _cookies_file: Option<&Path>,
+    ) -> Result<ArchiveResult> {
+        // Parse URL to get handle and post ID
+        let (handle, post_id) = Self::parse_url(url).context("Invalid Bluesky URL format")?;
+
+        // Resolve handle to DID
+        let did = self.resolve_handle(&handle).await?;
+
+        // Fetch the post
+        let post = self.get_post(&did, &post_id).await?;
+
+        // Prepare result
+        let mut result = ArchiveResult {
+            title: Some(format!("Post by @{}", post.author.handle)),
+            author: post
+                .author
+                .display_name
+                .clone()
+                .or(Some(post.author.handle.clone())),
+            text: Some(post.record.text.clone()),
+            content_type: "text".to_string(),
+            ..Default::default()
+        };
+
+        let mut image_urls = Vec::new();
+        let mut embed_type = None;
+        let mut external_url = None;
+
+        // Process embed if present
+        if let Some(embed) = &post.embed {
+            match embed {
+                Embed::Images { images } => {
+                    result.content_type = "image".to_string();
+                    embed_type = Some("images".to_string());
+
+                    // Download images
+                    for (i, img) in images.iter().enumerate() {
+                        image_urls.push(img.fullsize.clone());
+                        match self.download_image(&img.fullsize, work_dir, i).await {
+                            Ok(filename) => {
+                                if i == 0 {
+                                    result.primary_file = Some(filename);
+                                } else {
+                                    result.extra_files.push(filename);
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!("Failed to download image {}: {}", i, e);
+                            }
+                        }
+
+                        // Also download thumbnail as potential thumb
+                        if i == 0 {
+                            if let Ok(thumb_filename) =
+                                self.download_image(&img.thumb, work_dir, 999).await
+                            {
+                                result.thumbnail = Some(thumb_filename);
+                            }
+                        }
+                    }
+                }
+                Embed::Video(video) => {
+                    result.content_type = "video".to_string();
+                    embed_type = Some("video".to_string());
+
+                    // Download thumbnail if available
+                    if let Some(thumb_url) = &video.thumbnail {
+                        if let Ok(thumb_filename) =
+                            self.download_image(thumb_url, work_dir, 0).await
+                        {
+                            result.thumbnail = Some(thumb_filename);
+                        }
+                    }
+                }
+                Embed::External { external } => {
+                    embed_type = Some("external".to_string());
+                    external_url = Some(external.uri.clone());
+                    // Append external link info to text
+                    let ext_text = format!(
+                        "\n\n[External Link]\nTitle: {}\nDescription: {}\nURL: {}",
+                        external.title, external.description, external.uri
+                    );
+                    if let Some(ref mut text) = result.text {
+                        text.push_str(&ext_text);
+                    }
+                }
+                Embed::Record { .. } | Embed::RecordWithMedia { .. } => {
+                    embed_type = Some("quote".to_string());
+                }
+                Embed::Unknown => {}
+            }
+        }
+
+        // Create metadata JSON
+        let metadata = BlueskyMetadata {
+            uri: post.uri,
+            cid: post.cid,
+            author_did: post.author.did,
+            author_handle: post.author.handle,
+            author_display_name: post.author.display_name,
+            text: post.record.text,
+            created_at: post.record.created_at,
+            embed_type,
+            image_urls,
+            external_url,
+        };
+
+        let metadata_json =
+            serde_json::to_string_pretty(&metadata).context("Failed to serialize metadata")?;
+
+        // Write metadata file
+        let metadata_path = work_dir.join("metadata.json");
+        tokio::fs::write(&metadata_path, &metadata_json)
+            .await
+            .context("Failed to write metadata file")?;
+
+        result.metadata_json = Some(metadata_json);
+        result.extra_files.push("metadata.json".to_string());
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_can_handle() {
+        let handler = BlueskyHandler::new();
+
+        assert!(handler.can_handle("https://bsky.app/profile/alice.bsky.social/post/3abc123"));
+        assert!(handler.can_handle("https://bsky.social/profile/bob.dev/post/xyz789"));
+        assert!(handler.can_handle("https://bsky.app/profile/example.com/post/12345"));
+
+        assert!(!handler.can_handle("https://twitter.com/user/status/123"));
+        assert!(!handler.can_handle("https://bsky.app/profile/alice"));
+        assert!(!handler.can_handle("https://bsky.app/"));
+    }
+
+    #[test]
+    fn test_parse_url() {
+        let (handle, post_id) =
+            BlueskyHandler::parse_url("https://bsky.app/profile/alice.bsky.social/post/abc123")
+                .unwrap();
+        assert_eq!(handle, "alice.bsky.social");
+        assert_eq!(post_id, "abc123");
+
+        let (handle, post_id) =
+            BlueskyHandler::parse_url("https://bsky.social/profile/bob.dev/post/xyz").unwrap();
+        assert_eq!(handle, "bob.dev");
+        assert_eq!(post_id, "xyz");
+    }
+
+    #[test]
+    fn test_normalize_url() {
+        let handler = BlueskyHandler::new();
+
+        assert_eq!(
+            handler.normalize_url("https://bsky.social/profile/alice/post/123"),
+            "https://bsky.app/profile/alice/post/123"
+        );
+
+        assert_eq!(
+            handler.normalize_url("https://bsky.app/profile/alice/post/123"),
+            "https://bsky.app/profile/alice/post/123"
+        );
+    }
+
+    #[test]
+    fn test_site_id() {
+        let handler = BlueskyHandler::new();
+        assert_eq!(handler.site_id(), "bluesky");
+    }
+
+    #[test]
+    fn test_priority() {
+        let handler = BlueskyHandler::new();
+        assert_eq!(handler.priority(), 100);
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -3,10 +3,12 @@ mod registry;
 mod traits;
 
 // Site handlers
+mod bluesky;
 mod generic;
 mod imgur;
 mod instagram;
 mod reddit;
+mod streamable;
 mod tiktok;
 mod twitter;
 mod youtube;
@@ -26,6 +28,8 @@ pub static HANDLERS: Lazy<HandlerRegistry> = Lazy::new(|| {
     registry.register(Box::new(twitter::TwitterHandler::new()));
     registry.register(Box::new(instagram::InstagramHandler::new()));
     registry.register(Box::new(imgur::ImgurHandler::new()));
+    registry.register(Box::new(bluesky::BlueskyHandler::new()));
+    registry.register(Box::new(streamable::StreamableHandler::new()));
     registry.register(Box::new(generic::GenericHandler::new()));
     registry
 });

--- a/src/handlers/streamable.rs
+++ b/src/handlers/streamable.rs
@@ -1,0 +1,81 @@
+use std::path::Path;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use super::traits::{ArchiveResult, SiteHandler};
+use crate::archiver::ytdlp;
+
+static PATTERNS: Lazy<Vec<Regex>> =
+    Lazy::new(|| vec![Regex::new(r"^https?://(www\.)?streamable\.com/[a-zA-Z0-9]+").unwrap()]);
+
+pub struct StreamableHandler;
+
+impl StreamableHandler {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for StreamableHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SiteHandler for StreamableHandler {
+    fn site_id(&self) -> &'static str {
+        "streamable"
+    }
+
+    fn url_patterns(&self) -> &[Regex] {
+        &PATTERNS
+    }
+
+    fn priority(&self) -> i32 {
+        100
+    }
+
+    async fn archive(
+        &self,
+        url: &str,
+        work_dir: &Path,
+        cookies_file: Option<&Path>,
+    ) -> Result<ArchiveResult> {
+        ytdlp::download(url, work_dir, cookies_file).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_can_handle() {
+        let handler = StreamableHandler::new();
+
+        assert!(handler.can_handle("https://streamable.com/abc123"));
+        assert!(handler.can_handle("https://www.streamable.com/abc123"));
+        assert!(handler.can_handle("http://streamable.com/xyz789"));
+
+        assert!(!handler.can_handle("https://example.com/"));
+        assert!(!handler.can_handle("https://youtube.com/watch?v=abc"));
+        assert!(!handler.can_handle("https://streamable.com/")); // No video ID
+    }
+
+    #[test]
+    fn test_site_id() {
+        let handler = StreamableHandler::new();
+        assert_eq!(handler.site_id(), "streamable");
+    }
+
+    #[test]
+    fn test_priority() {
+        let handler = StreamableHandler::new();
+        assert_eq!(handler.priority(), 100);
+    }
+}

--- a/src/ipfs/mod.rs
+++ b/src/ipfs/mod.rs
@@ -312,6 +312,8 @@ mod tests {
             web_port: 8080,
             wayback_enabled: false,
             wayback_rate_limit_per_min: 5,
+            archive_today_enabled: false,
+            archive_today_rate_limit_per_min: 3,
             backup_enabled: false,
             backup_interval_hours: 24,
             backup_retention_count: 30,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 // Allow raw string hashes for safety - they're harmless and prevent issues if content changes
 #![allow(clippy::needless_raw_string_hashes)]
 
+pub mod archive_today;
 pub mod archiver;
 pub mod backup;
 pub mod config;

--- a/src/web/feeds.rs
+++ b/src/web/feeds.rs
@@ -1,0 +1,131 @@
+use crate::db::Archive;
+
+/// Generate RSS 2.0 feed XML
+pub fn generate_rss(archives: &[Archive], base_url: &str) -> String {
+    let items: String = archives
+        .iter()
+        .map(|archive| {
+            let title = xml_escape(
+                archive
+                    .content_title
+                    .as_deref()
+                    .unwrap_or("Untitled Archive"),
+            );
+            let link = format!("{}/archive/{}", base_url, archive.id);
+            let description = xml_escape(archive.content_text.as_deref().unwrap_or(""));
+            let pub_date = archive.archived_at.as_deref().unwrap_or("");
+            let content_type = archive.content_type.as_deref().unwrap_or("unknown");
+
+            format!(
+                r#"    <item>
+      <title>{title}</title>
+      <link>{link}</link>
+      <guid isPermaLink="true">{link}</guid>
+      <description><![CDATA[{description}]]></description>
+      <pubDate>{pub_date}</pubDate>
+      <category>{content_type}</category>
+    </item>"#
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Discourse Link Archiver - New Archives</title>
+    <link>{base_url}</link>
+    <description>Recently archived content from the Discourse Link Archiver</description>
+    <language>en-us</language>
+    <atom:link href="{base_url}/feed.rss" rel="self" type="application/rss+xml"/>
+{items}
+  </channel>
+</rss>"#
+    )
+}
+
+/// Generate Atom 1.0 feed XML
+pub fn generate_atom(archives: &[Archive], base_url: &str) -> String {
+    let now = chrono::Utc::now().to_rfc3339();
+
+    let entries: String = archives
+        .iter()
+        .map(|archive| {
+            let title = xml_escape(
+                archive
+                    .content_title
+                    .as_deref()
+                    .unwrap_or("Untitled Archive"),
+            );
+            let link = format!("{}/archive/{}", base_url, archive.id);
+            let summary = xml_escape(archive.content_text.as_deref().unwrap_or(""));
+            let updated = archive.archived_at.as_deref().unwrap_or(&now);
+            let author = xml_escape(archive.content_author.as_deref().unwrap_or("Unknown"));
+            let content_type = archive.content_type.as_deref().unwrap_or("unknown");
+
+            format!(
+                r#"  <entry>
+    <title>{title}</title>
+    <link href="{link}" rel="alternate" type="text/html"/>
+    <id>{link}</id>
+    <updated>{updated}</updated>
+    <author><name>{author}</name></author>
+    <summary><![CDATA[{summary}]]></summary>
+    <category term="{content_type}"/>
+  </entry>"#
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Discourse Link Archiver - New Archives</title>
+  <link href="{base_url}" rel="alternate" type="text/html"/>
+  <link href="{base_url}/feed.atom" rel="self" type="application/atom+xml"/>
+  <id>{base_url}/</id>
+  <updated>{now}</updated>
+  <subtitle>Recently archived content from the Discourse Link Archiver</subtitle>
+{entries}
+</feed>"#
+    )
+}
+
+/// Escape XML special characters
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_rss_empty() {
+        let rss = generate_rss(&[], "https://example.com");
+        assert!(rss.contains("<?xml version="));
+        assert!(rss.contains("<rss version=\"2.0\""));
+        assert!(rss.contains("Discourse Link Archiver"));
+    }
+
+    #[test]
+    fn test_generate_atom_empty() {
+        let atom = generate_atom(&[], "https://example.com");
+        assert!(atom.contains("<?xml version="));
+        assert!(atom.contains("<feed xmlns="));
+        assert!(atom.contains("Discourse Link Archiver"));
+    }
+
+    #[test]
+    fn test_xml_escape() {
+        assert_eq!(xml_escape("<script>"), "&lt;script&gt;");
+        assert_eq!(xml_escape("a & b"), "a &amp; b");
+        assert_eq!(xml_escape("\"test\""), "&quot;test&quot;");
+    }
+}

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1,3 +1,4 @@
+mod feeds;
 mod routes;
 mod templates;
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,5 +1,51 @@
 /* Discourse Link Archiver - Custom Styles */
 
+/* Theme toggle button */
+.theme-toggle {
+    padding: 0.25rem 0.5rem;
+    font-size: 1rem;
+    cursor: pointer;
+    border: none;
+    background: transparent;
+    margin: 0;
+}
+
+.theme-toggle:hover {
+    opacity: 0.8;
+}
+
+/* Dark mode specific overrides */
+[data-theme="dark"] .status-complete {
+    color: #4ade80;
+}
+
+[data-theme="dark"] .status-pending {
+    color: #fbbf24;
+}
+
+[data-theme="dark"] .status-failed {
+    color: #f87171;
+}
+
+[data-theme="dark"] .status-skipped {
+    color: #9ca3af;
+}
+
+[data-theme="dark"] .status-processing {
+    color: #60a5fa;
+}
+
+[data-theme="dark"] .error-message {
+    background-color: rgba(248, 113, 113, 0.15);
+    border-color: #f87171;
+    color: #fca5a5;
+}
+
+[data-theme="dark"] .archive-card {
+    border-color: var(--pico-muted-border-color);
+    background-color: var(--pico-card-background-color);
+}
+
 /* Archive Card */
 .archive-card {
     border: 1px solid var(--pico-muted-border-color);


### PR DESCRIPTION
New features:
- Bluesky handler: fetch posts via AT Protocol public API, download images
- Streamable handler: simple yt-dlp passthrough for video archiving
- Archive.today integration: alternative to Wayback Machine with rate limiting
- RSS/Atom feeds: /feed.rss and /feed.atom for new archives
- Dark mode: system preference detection with manual toggle

Changes:
- Add archive_today_url column to archives table (migration v3)
- Add ARCHIVE_TODAY_ENABLED and ARCHIVE_TODAY_RATE_LIMIT_PER_MIN config
- Update web UI with dark mode CSS and theme toggle
- Add feed links in header and footer
- Update SPEC.md and MAIN_TASKS.md with new feature documentation