### PR TITLE
Skip archiving same-domain links and add Deno runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     python3-venv \
+    unzip \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Deno (JS runtime for yt-dlp)
+RUN curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/opt/deno sh
+ENV PATH="/opt/deno/bin:$PATH"
 
 # Create a virtual environment for Python tools
 RUN python3 -m venv /opt/venv


### PR DESCRIPTION
- Add domain filtering to skip archiving links to the forum's own domain during RSS sync (self-links don't need to be archived)
- Add Deno JS runtime to Dockerfile for yt-dlp to use when extracting from sites that require JavaScript execution
- Add domains_match() helper that handles www prefix and case differences
- Include unit tests for domain matching logic