### PR TITLE
Implement screenshot capture and archive retry logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.3",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -232,6 +232,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "async-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5359381fd414fbdb272c48f2111c16cb0bb3447bfacd59311ff3736da9f6664"
+dependencies = [
+ "futures-io",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -526,6 +540,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chromiumoxide"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8380ce7721cc895fe8a184c49d615fe755b0c9a3d7986355cee847439fff907f"
+dependencies = [
+ "async-tungstenite",
+ "base64 0.22.1",
+ "cfg-if",
+ "chromiumoxide_cdp",
+ "chromiumoxide_types",
+ "dunce",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "pin-project-lite",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "url",
+ "which",
+ "winreg",
+]
+
+[[package]]
+name = "chromiumoxide_cdp"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadbfb52fa0aeca43626f6c42ca04184b108b786f8e45198dc41a42aedcf2e50"
+dependencies = [
+ "chromiumoxide_pdl",
+ "chromiumoxide_types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_pdl"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c197aeb42872c5d4c923e7d8ad46d99a58fd0fec37f6491554ff677a6791d3c9"
+dependencies = [
+ "chromiumoxide_types",
+ "either",
+ "heck 0.4.1",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923486888790528d55ac37ec2f7483ed19eb8ccbb44701878e5856d1ceadf5d8"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +875,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-server",
+ "chromiumoxide",
  "chrono",
  "dotenvy",
  "feed-rs",
@@ -1149,6 +1230,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,6 +1358,12 @@ checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1735,6 +1828,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -2191,7 +2290,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -2581,6 +2680,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -2588,7 +2700,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -3085,7 +3197,7 @@ checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.5.0",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -3293,7 +3405,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -3695,6 +3807,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3930,6 +4060,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
 ]
 
 [[package]]
@@ -4231,6 +4373,22 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wiremock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,9 @@ zstd = "0.13"
 # Text diffing
 similar = "2"
 
+# Browser automation for screenshots
+chromiumoxide = { version = "0.7", default-features = false, features = ["tokio-runtime"] }
+
 [dev-dependencies]
 tempfile = "3"
 wiremock = "0.6"

--- a/MAIN_TASKS.md
+++ b/MAIN_TASKS.md
@@ -298,14 +298,14 @@ Legend: `[ ]` pending, `[x]` complete, `[-]` skipped/blocked
 - [ ] Write unit tests for hash comparison
 
 ### Screenshot Capture
-- [ ] Add chromiumoxide or headless_chrome dependency
-- [ ] Create screenshot capture module
-- [ ] Configure viewport dimensions
-- [ ] Capture full-page screenshots as PNG
-- [ ] Store in S3 render/ directory
-- [ ] Add configuration options
-- [ ] Handle browser startup/cleanup
-- [ ] Write unit tests
+- [x] Add chromiumoxide or headless_chrome dependency
+- [x] Create screenshot capture module
+- [x] Configure viewport dimensions
+- [x] Capture full-page screenshots as PNG
+- [x] Store in S3 render/ directory
+- [x] Add configuration options
+- [x] Handle browser startup/cleanup
+- [x] Write unit tests
 
 ### PDF Generation
 - [ ] Use browser print-to-PDF capability
@@ -390,3 +390,11 @@ Add new tasks here as they are discovered during development:
 - [x] Create lib.rs to expose modules for integration tests
 - [x] Write database integration tests
 - [x] Write web routes integration tests
+
+### Archive Retry Improvements
+- [x] Add `next_retry_at` and `last_attempt_at` columns to archives table (migration v5)
+- [x] Implement exponential backoff for failed archives (5, 10, 20, 40 minutes)
+- [x] Update retry query to respect `next_retry_at` timestamp
+- [x] Reset stuck "processing" archives to "pending" on startup
+- [x] Reset failed archives from today for retry on container restart
+- [x] Add startup recovery function to archive worker

--- a/src/archiver/mod.rs
+++ b/src/archiver/mod.rs
@@ -1,7 +1,9 @@
 pub mod gallerydl;
 pub mod rate_limiter;
+pub mod screenshot;
 pub mod worker;
 pub mod ytdlp;
 
 pub use rate_limiter::DomainRateLimiter;
+pub use screenshot::{ScreenshotConfig, ScreenshotService};
 pub use worker::ArchiveWorker;

--- a/src/archiver/screenshot.rs
+++ b/src/archiver/screenshot.rs
@@ -1,0 +1,236 @@
+//! Screenshot capture module using headless Chrome/Chromium.
+//!
+//! This module provides functionality to capture full-page screenshots
+//! of web pages using a headless browser.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use chromiumoxide::browser::{Browser, BrowserConfig};
+use chromiumoxide::page::ScreenshotParams;
+use futures_util::StreamExt;
+use tokio::sync::Mutex;
+use tracing::{debug, error, info, warn};
+
+/// Default viewport width in pixels.
+pub const DEFAULT_VIEWPORT_WIDTH: u32 = 1280;
+
+/// Default viewport height in pixels.
+pub const DEFAULT_VIEWPORT_HEIGHT: u32 = 800;
+
+/// Default page load timeout in seconds.
+pub const DEFAULT_PAGE_TIMEOUT_SECS: u64 = 30;
+
+/// Screenshot capture configuration.
+#[derive(Debug, Clone)]
+pub struct ScreenshotConfig {
+    /// Viewport width in pixels.
+    pub viewport_width: u32,
+    /// Viewport height in pixels.
+    pub viewport_height: u32,
+    /// Page load timeout.
+    pub page_timeout: Duration,
+    /// Path to Chrome/Chromium executable (None for auto-detection).
+    pub chrome_path: Option<String>,
+    /// Whether screenshot capture is enabled.
+    pub enabled: bool,
+}
+
+impl Default for ScreenshotConfig {
+    fn default() -> Self {
+        Self {
+            viewport_width: DEFAULT_VIEWPORT_WIDTH,
+            viewport_height: DEFAULT_VIEWPORT_HEIGHT,
+            page_timeout: Duration::from_secs(DEFAULT_PAGE_TIMEOUT_SECS),
+            chrome_path: None,
+            enabled: false,
+        }
+    }
+}
+
+/// Screenshot capture service.
+///
+/// Manages a headless browser instance for capturing screenshots.
+/// The browser is lazily initialized on first use.
+pub struct ScreenshotService {
+    config: ScreenshotConfig,
+    browser: Arc<Mutex<Option<Browser>>>,
+}
+
+impl ScreenshotService {
+    /// Create a new screenshot service.
+    #[must_use]
+    pub fn new(config: ScreenshotConfig) -> Self {
+        Self {
+            config,
+            browser: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Check if screenshot capture is enabled.
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        self.config.enabled
+    }
+
+    /// Initialize the browser if not already running.
+    async fn ensure_browser(&self) -> Result<()> {
+        let mut browser_guard = self.browser.lock().await;
+        if browser_guard.is_some() {
+            return Ok(());
+        }
+
+        info!("Initializing headless browser for screenshots");
+
+        let mut config_builder = BrowserConfig::builder()
+            .window_size(self.config.viewport_width, self.config.viewport_height)
+            .request_timeout(self.config.page_timeout)
+            .no_sandbox()
+            .disable_default_args()
+            .arg("--headless=new")
+            .arg("--disable-gpu")
+            .arg("--disable-dev-shm-usage")
+            .arg("--disable-software-rasterizer")
+            .arg("--no-first-run")
+            .arg("--no-default-browser-check")
+            .arg("--disable-background-networking")
+            .arg("--disable-extensions")
+            .arg("--disable-sync")
+            .arg("--disable-translate")
+            .arg("--mute-audio")
+            .arg("--hide-scrollbars");
+
+        if let Some(ref chrome_path) = self.config.chrome_path {
+            config_builder = config_builder.chrome_executable(chrome_path);
+        }
+
+        let browser_config = config_builder
+            .build()
+            .map_err(|e| anyhow::anyhow!("Failed to build browser config: {e}"))?;
+
+        let (browser, mut handler) = Browser::launch(browser_config)
+            .await
+            .context("Failed to launch browser")?;
+
+        // Spawn handler in background
+        tokio::spawn(async move {
+            while let Some(event) = handler.next().await {
+                if let Err(e) = event {
+                    debug!("Browser handler error: {e}");
+                }
+            }
+        });
+
+        *browser_guard = Some(browser);
+        info!("Headless browser initialized");
+
+        Ok(())
+    }
+
+    /// Capture a screenshot of the given URL.
+    ///
+    /// Returns the screenshot as PNG bytes.
+    pub async fn capture(&self, url: &str) -> Result<Vec<u8>> {
+        if !self.config.enabled {
+            anyhow::bail!("Screenshot capture is disabled");
+        }
+
+        self.ensure_browser().await?;
+
+        let browser_guard = self.browser.lock().await;
+        let browser = browser_guard.as_ref().context("Browser not initialized")?;
+
+        debug!(url = %url, "Capturing screenshot");
+
+        // Create a new page
+        let page = browser
+            .new_page(url)
+            .await
+            .context("Failed to create new page")?;
+
+        // Wait for the page to load
+        page.wait_for_navigation()
+            .await
+            .context("Navigation timeout")?;
+
+        // Give the page a bit more time to render dynamic content
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // Capture full page screenshot using the high-level API
+        let screenshot_params = ScreenshotParams::builder().full_page(true).build();
+
+        let png_data = page
+            .screenshot(screenshot_params)
+            .await
+            .context("Failed to capture screenshot")?;
+
+        // Close the page
+        if let Err(e) = page.close().await {
+            warn!("Failed to close page: {e}");
+        }
+
+        debug!(url = %url, size = png_data.len(), "Screenshot captured");
+
+        Ok(png_data)
+    }
+
+    /// Capture a screenshot and save it to a file.
+    pub async fn capture_to_file(&self, url: &str, output_path: &Path) -> Result<()> {
+        let png_data = self.capture(url).await?;
+        tokio::fs::write(output_path, &png_data)
+            .await
+            .with_context(|| format!("Failed to write screenshot to {}", output_path.display()))?;
+        Ok(())
+    }
+
+    /// Shutdown the browser gracefully.
+    pub async fn shutdown(&self) {
+        let mut browser_guard = self.browser.lock().await;
+        if let Some(mut browser) = browser_guard.take() {
+            if let Err(e) = browser.close().await {
+                error!("Failed to close browser: {e}");
+            } else {
+                info!("Browser shutdown complete");
+            }
+        }
+    }
+}
+
+impl Drop for ScreenshotService {
+    fn drop(&mut self) {
+        // Note: We can't do async cleanup in Drop, but the browser process
+        // will be killed when the Browser struct is dropped
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = ScreenshotConfig::default();
+        assert_eq!(config.viewport_width, DEFAULT_VIEWPORT_WIDTH);
+        assert_eq!(config.viewport_height, DEFAULT_VIEWPORT_HEIGHT);
+        assert!(!config.enabled);
+    }
+
+    #[test]
+    fn test_service_disabled_by_default() {
+        let config = ScreenshotConfig::default();
+        let service = ScreenshotService::new(config);
+        assert!(!service.is_enabled());
+    }
+
+    #[test]
+    fn test_service_enabled() {
+        let config = ScreenshotConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let service = ScreenshotService::new(config);
+        assert!(service.is_enabled());
+    }
+}

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -123,6 +123,10 @@ pub struct Archive {
     pub is_nsfw: bool,
     /// Source of the NSFW flag: 'api', 'metadata', 'subreddit', 'manual'.
     pub nsfw_source: Option<String>,
+    /// When the archive is eligible for retry (for exponential backoff).
+    pub next_retry_at: Option<String>,
+    /// When the last archive attempt was made.
+    pub last_attempt_at: Option<String>,
 }
 
 impl Archive {

--- a/src/ipfs/mod.rs
+++ b/src/ipfs/mod.rs
@@ -332,6 +332,11 @@ mod tests {
             ],
             submission_enabled: true,
             submission_rate_limit_per_hour: 10,
+            screenshot_enabled: false,
+            screenshot_viewport_width: 1280,
+            screenshot_viewport_height: 800,
+            screenshot_timeout_secs: 30,
+            screenshot_chrome_path: None,
         };
 
         let client = IpfsClient::new(&config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,12 @@ async fn run() -> Result<()> {
     let worker_s3 = s3_client;
     let worker_ipfs = ipfs_client;
     let worker = ArchiveWorker::new(worker_config, worker_db, worker_s3, worker_ipfs);
+
+    // Recover from any interrupted processing on startup
+    if let Err(e) = worker.recover_on_startup().await {
+        error!("Failed to recover archives on startup: {e:#}");
+    }
+
     let worker_handle = tokio::spawn(async move {
         worker.run().await;
     });

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -96,6 +96,11 @@ mod tests {
             ipfs_gateway_urls: vec![],
             submission_enabled: false,
             submission_rate_limit_per_hour: 10,
+            screenshot_enabled: false,
+            screenshot_viewport_width: 1280,
+            screenshot_viewport_height: 800,
+            screenshot_timeout_secs: 30,
+            screenshot_chrome_path: None,
         }
     }
 

--- a/tests/archive_pipeline_test.rs
+++ b/tests/archive_pipeline_test.rs
@@ -53,6 +53,11 @@ fn create_test_config(work_dir: &std::path::Path) -> Config {
         ipfs_gateway_urls: vec![],
         submission_enabled: false,
         submission_rate_limit_per_hour: 10,
+        screenshot_enabled: false,
+        screenshot_viewport_width: 1280,
+        screenshot_viewport_height: 800,
+        screenshot_timeout_secs: 30,
+        screenshot_chrome_path: None,
     }
 }
 

--- a/tests/rss_poll_test.rs
+++ b/tests/rss_poll_test.rs
@@ -52,6 +52,11 @@ fn create_test_config(rss_url: &str, work_dir: &std::path::Path) -> Config {
         ipfs_gateway_urls: vec![],
         submission_enabled: false,
         submission_rate_limit_per_hour: 10,
+        screenshot_enabled: false,
+        screenshot_viewport_width: 1280,
+        screenshot_viewport_height: 800,
+        screenshot_timeout_secs: 30,
+        screenshot_chrome_path: None,
     }
 }
 


### PR DESCRIPTION
…koff

Screenshot Capture:
- Add chromiumoxide dependency for headless browser automation
- Create screenshot capture module with configurable viewport size
- Integrate screenshot capture into archive pipeline (optional, non-fatal)
- Store screenshots in S3 under render/screenshot.png
- Add configuration options (SCREENSHOT_ENABLED, viewport, timeout, chrome path)

Archive Retry Improvements:
- Add migration v5: next_retry_at and last_attempt_at columns
- Implement exponential backoff for failed archives (5, 10, 20, 40 min delays)
- Reset stuck "processing" archives to "pending" on startup
- Reset today's failed archives for retry on container restart
- Add recover_on_startup() function to archive worker

This improves reliability by:
1. Giving transient failures (500 errors, timeouts) time to resolve
2. Recovering from container restarts gracefully
3. Not hammering failing endpoints repeatedly