### PR TITLE
Handle redirect links in debugging

### DIFF
--- a/src/archiver/gallerydl.rs
+++ b/src/archiver/gallerydl.rs
@@ -160,6 +160,7 @@ async fn find_and_parse_files(work_dir: &Path) -> Result<ArchiveResult> {
         metadata_json,
         is_nsfw: None,
         nsfw_source: None,
+        final_url: None,
     })
 }
 

--- a/src/handlers/traits.rs
+++ b/src/handlers/traits.rs
@@ -29,6 +29,8 @@ pub struct ArchiveResult {
     pub is_nsfw: Option<bool>,
     /// Source of the NSFW determination (api, metadata, subreddit).
     pub nsfw_source: Option<String>,
+    /// Final URL after following redirects (if different from original).
+    pub final_url: Option<String>,
 }
 
 impl Default for ArchiveResult {
@@ -44,6 +46,7 @@ impl Default for ArchiveResult {
             metadata_json: None,
             is_nsfw: None,
             nsfw_source: None,
+            final_url: None,
         }
     }
 }


### PR DESCRIPTION
Implements automatic redirect following for Reddit URLs to capture the final canonical URL. Some Reddit URLs (e.g., /comment/xyz) redirect to the full path with post title slugs, which was causing content to be missing.

Changes:
- Add `final_url` field to `ArchiveResult` to track the URL after redirects
- Implement `follow_redirects()` function in Reddit handler to follow up to 5 redirects
- Update Reddit handler's `archive()` method to follow redirects and use the final URL for fetching
- Update archiver worker to save final URL to database via `update_link_final_url()`
- Add `final_url` to all `ArchiveResult` instantiations

The final URL is now stored in the database and can be displayed in the web UI to show users which URL was actually archived.