### PR TITLE
Log archive attempt results to database

### DIFF
--- a/src/archiver/ytdlp.rs
+++ b/src/archiver/ytdlp.rs
@@ -47,7 +47,7 @@ pub async fn download(
     // Only use one method to avoid potential conflicts
     let mut cookie_method_used = false;
 
-    if let Some(ref spec) = cookies.browser_profile {
+    if let Some(spec) = cookies.browser_profile {
         let spec = maybe_adjust_chromium_user_data_dir_spec(spec);
         debug!(spec = %spec, "Using cookies from browser profile");
         args.push("--cookies-from-browser".to_string());


### PR DESCRIPTION
- Display error details (error message, last attempt, retry count) for failed/skipped archives on the archive detail page
- Add re-archive button to trigger a fresh archive attempt through the full pipeline including redirect handling
- Add database query to reset archive state and clear old artifacts
- Show status with icons (✓ ✗ ⏳ ⟳ ⊘) on archive detail page

The re-archive feature is intended for debugging and can be disabled later. Max retries (3) for failed archives is already implemented in the worker.