### PR TITLE
Archive CSS with HTML pages

### DIFF
--- a/MAIN_TASKS.md
+++ b/MAIN_TASKS.md
@@ -415,13 +415,16 @@ Add new tasks here as they are discovered during development:
 - [x] Fix extra_files upload in worker - handlers can return extra files but they weren't uploaded
 - [x] Embed CSS in archive banner for offline viewing (inline styles in view.html)
 
-### HTML/PDF Archiving Workflow (reviewed - see notes)
-Current status: PDFs and screenshots work well offline. HTML archives need external CSS/images to render fully.
-Known gaps (for future work):
-- [ ] Embed external CSS inline in HTML archives for offline viewing
-- [ ] Embed/download referenced images for HTML archives
-- [ ] Support font embedding for archived webpages
-- [ ] Create self-contained HTML option with all resources embedded
+### HTML/PDF Archiving Workflow
+Status: Complete. Full offline archiving implemented with multiple output formats.
+Implemented:
+- [x] Embed external CSS inline in HTML archives for offline viewing (via monolith)
+- [x] Embed/download referenced images for HTML archives (via monolith)
+- [x] Support font embedding for archived webpages (via monolith)
+- [x] Create self-contained HTML option with all resources embedded (complete.html via monolith)
+- [x] Add MHTML archive format (complete.mhtml via Chrome CDP)
+- [x] Screenshot capture (screenshot.png via headless Chrome)
+- [x] PDF generation (page.pdf via headless Chrome)
 
 ### Future Improvements
 - [ ] Upgrade axum from 0.7 to 0.8 (breaking change: path syntax changes from `:param` to `{param}`)

--- a/config.example.toml
+++ b/config.example.toml
@@ -113,3 +113,45 @@ gateway_urls = [
 enabled = true
 # Maximum submissions per hour per IP address
 rate_limit_per_hour = 60
+
+[screenshot]
+# Enable screenshot capture (requires Chromium)
+enabled = false
+# Viewport width in pixels
+viewport_width = 1280
+# Viewport height in pixels (taller = more content captured)
+viewport_height = 3000
+# Page load timeout in seconds
+timeout_secs = 30
+# Path to Chrome/Chromium executable (optional, auto-detected if not set)
+# chrome_path = "/usr/bin/chromium"
+
+[pdf]
+# Enable PDF generation (requires Chromium)
+enabled = false
+# Paper width in inches (8.27 = A4)
+paper_width = 8.27
+# Paper height in inches (11.69 = A4)
+paper_height = 11.69
+
+[mhtml]
+# Enable MHTML archive generation (requires Chromium)
+# MHTML bundles HTML + CSS + images into a single file
+enabled = false
+
+[monolith]
+# Enable self-contained HTML generation using monolith
+# Creates complete.html with CSS, images, and fonts embedded as data URIs
+enabled = false
+# Path to monolith executable
+path = "monolith"
+# Timeout for monolith execution in seconds
+timeout_secs = 60
+# Include JavaScript in archived pages (may cause issues with some sites)
+include_js = false
+
+[dedup]
+# Enable content deduplication (saves storage by detecting similar media)
+enabled = true
+# Perceptual hash similarity threshold (0-64, lower = stricter matching)
+similarity_threshold = 10

--- a/src/archiver/mod.rs
+++ b/src/archiver/mod.rs
@@ -1,13 +1,15 @@
 use std::path::Path;
 
 pub mod gallerydl;
+pub mod monolith;
 pub mod rate_limiter;
 pub mod screenshot;
 pub mod worker;
 pub mod ytdlp;
 
+pub use monolith::{create_complete_html, MonolithConfig};
 pub use rate_limiter::DomainRateLimiter;
-pub use screenshot::{PdfConfig, ScreenshotConfig, ScreenshotService};
+pub use screenshot::{MhtmlConfig, PdfConfig, ScreenshotConfig, ScreenshotService};
 pub use worker::ArchiveWorker;
 
 /// Cookie options for archive downloads.

--- a/src/archiver/monolith.rs
+++ b/src/archiver/monolith.rs
@@ -1,0 +1,202 @@
+//! Monolith wrapper for creating self-contained HTML archives.
+//!
+//! Monolith is a CLI tool that bundles a web page with all its resources
+//! (CSS, images, fonts, JavaScript) into a single HTML file using data URIs.
+//! This ensures the archived page renders correctly offline.
+
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::process::Command;
+use tracing::{debug, warn};
+
+/// Default timeout for monolith execution in seconds.
+pub const DEFAULT_MONOLITH_TIMEOUT_SECS: u64 = 60;
+
+/// Configuration for monolith HTML archiving.
+#[derive(Debug, Clone)]
+pub struct MonolithConfig {
+    /// Whether monolith archiving is enabled.
+    pub enabled: bool,
+    /// Path to the monolith executable.
+    pub path: String,
+    /// Timeout for monolith execution.
+    pub timeout: Duration,
+    /// Whether to include JavaScript in the archive.
+    pub include_js: bool,
+}
+
+impl Default for MonolithConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            path: "monolith".to_string(),
+            timeout: Duration::from_secs(DEFAULT_MONOLITH_TIMEOUT_SECS),
+            include_js: false,
+        }
+    }
+}
+
+/// Create a self-contained HTML file from a URL using monolith.
+///
+/// The output file will contain all CSS, images, and fonts embedded as data URIs,
+/// making it viewable offline without any external dependencies.
+///
+/// # Arguments
+///
+/// * `url` - The URL to archive
+/// * `output_path` - Where to save the self-contained HTML file
+/// * `cookies_file` - Optional path to a cookies.txt file for authenticated requests
+/// * `config` - Monolith configuration
+///
+/// # Errors
+///
+/// Returns an error if monolith fails to execute or times out.
+pub async fn create_complete_html(
+    url: &str,
+    output_path: &Path,
+    cookies_file: Option<&Path>,
+    config: &MonolithConfig,
+) -> Result<()> {
+    if !config.enabled {
+        anyhow::bail!("Monolith archiving is disabled");
+    }
+
+    debug!(url = %url, output = %output_path.display(), "Creating self-contained HTML with monolith");
+
+    let mut cmd = Command::new(&config.path);
+
+    // Input URL
+    cmd.arg(url);
+
+    // Output file
+    cmd.arg("-o").arg(output_path);
+
+    // Isolate mode - prevents external requests when viewing the saved file
+    cmd.arg("-I");
+
+    // Include CSS (always)
+    cmd.arg("-s");
+
+    // Include images (always)
+    cmd.arg("-i");
+
+    // Include fonts (always)
+    cmd.arg("-f");
+
+    // Include JavaScript (configurable - some sites need it, but it can also cause issues)
+    if config.include_js {
+        cmd.arg("-j");
+    } else {
+        cmd.arg("-J"); // Exclude JavaScript
+    }
+
+    // Include iframes
+    cmd.arg("-F");
+
+    // Set a reasonable timeout for network requests (in seconds)
+    cmd.arg("-t").arg("30");
+
+    // Use a reasonable user agent
+    cmd.arg("-u").arg("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+
+    // Cookies file if provided
+    if let Some(cookies) = cookies_file {
+        if cookies.exists() {
+            cmd.arg("-c").arg(cookies);
+        }
+    }
+
+    // Suppress stdout, capture stderr
+    cmd.stdout(Stdio::null());
+    cmd.stderr(Stdio::piped());
+
+    // Execute with timeout
+    let output = tokio::time::timeout(config.timeout, cmd.output())
+        .await
+        .context("Monolith execution timed out")?
+        .context("Failed to execute monolith")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Log warning but don't fail - monolith can fail on some pages but still produce useful output
+        if !output_path.exists() {
+            anyhow::bail!(
+                "Monolith failed with exit code {:?}: {}",
+                output.status.code(),
+                stderr.trim()
+            );
+        }
+        warn!(
+            url = %url,
+            exit_code = ?output.status.code(),
+            stderr = %stderr.trim(),
+            "Monolith completed with warnings"
+        );
+    }
+
+    // Verify output file was created
+    if !output_path.exists() {
+        anyhow::bail!("Monolith did not create output file");
+    }
+
+    let file_size = tokio::fs::metadata(output_path)
+        .await
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    debug!(
+        url = %url,
+        output = %output_path.display(),
+        size = file_size,
+        "Self-contained HTML created successfully"
+    );
+
+    Ok(())
+}
+
+/// Check if monolith is available and working.
+pub async fn check_monolith(path: &str) -> Result<String> {
+    let output = Command::new(path)
+        .arg("--version")
+        .output()
+        .await
+        .context("Failed to execute monolith")?;
+
+    if !output.status.success() {
+        anyhow::bail!("Monolith version check failed");
+    }
+
+    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = MonolithConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.path, "monolith");
+        assert_eq!(config.timeout, Duration::from_secs(60));
+        assert!(!config.include_js);
+    }
+
+    #[test]
+    fn test_custom_config() {
+        let config = MonolithConfig {
+            enabled: true,
+            path: "/usr/local/bin/monolith".to_string(),
+            timeout: Duration::from_secs(120),
+            include_js: true,
+        };
+        assert!(config.enabled);
+        assert_eq!(config.path, "/usr/local/bin/monolith");
+        assert_eq!(config.timeout, Duration::from_secs(120));
+        assert!(config.include_js);
+    }
+}

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -141,6 +141,9 @@ impl Archive {
 #[serde(rename_all = "snake_case")]
 pub enum ArtifactKind {
     RawHtml,
+    ViewHtml,
+    CompleteHtml,
+    Mhtml,
     Screenshot,
     Pdf,
     Video,
@@ -155,6 +158,9 @@ impl ArtifactKind {
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::RawHtml => "raw_html",
+            Self::ViewHtml => "view_html",
+            Self::CompleteHtml => "complete_html",
+            Self::Mhtml => "mhtml",
             Self::Screenshot => "screenshot",
             Self::Pdf => "pdf",
             Self::Video => "video",

--- a/src/ipfs/mod.rs
+++ b/src/ipfs/mod.rs
@@ -342,6 +342,11 @@ mod tests {
             pdf_enabled: false,
             pdf_paper_width: 8.27,
             pdf_paper_height: 11.69,
+            mhtml_enabled: false,
+            monolith_enabled: false,
+            monolith_path: "monolith".to_string(),
+            monolith_timeout_secs: 60,
+            monolith_include_js: false,
             dedup_enabled: false,
             dedup_similarity_threshold: 10,
         };

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -105,6 +105,11 @@ mod tests {
             pdf_enabled: false,
             pdf_paper_width: 8.27,
             pdf_paper_height: 11.69,
+            mhtml_enabled: false,
+            monolith_enabled: false,
+            monolith_path: "monolith".to_string(),
+            monolith_timeout_secs: 60,
+            monolith_include_js: false,
             dedup_enabled: false,
             dedup_similarity_threshold: 10,
         }

--- a/tests/archive_pipeline_test.rs
+++ b/tests/archive_pipeline_test.rs
@@ -63,6 +63,11 @@ fn create_test_config(work_dir: &std::path::Path) -> Config {
         pdf_enabled: false,
         pdf_paper_width: 8.27,
         pdf_paper_height: 11.69,
+        mhtml_enabled: false,
+        monolith_enabled: false,
+        monolith_path: "monolith".to_string(),
+        monolith_timeout_secs: 60,
+        monolith_include_js: false,
         dedup_enabled: false,
         dedup_similarity_threshold: 10,
     }

--- a/tests/rss_poll_test.rs
+++ b/tests/rss_poll_test.rs
@@ -61,6 +61,11 @@ fn create_test_config(rss_url: &str, work_dir: &std::path::Path) -> Config {
         pdf_enabled: false,
         pdf_paper_width: 8.27,
         pdf_paper_height: 11.69,
+        mhtml_enabled: false,
+        monolith_enabled: false,
+        monolith_path: "monolith".to_string(),
+        monolith_timeout_secs: 60,
+        monolith_include_js: false,
         dedup_enabled: false,
         dedup_similarity_threshold: 10,
     }


### PR DESCRIPTION
Implements full offline HTML archiving with multiple output formats:

- Add monolith integration for self-contained HTML (complete.html)
  - Embeds CSS, images, fonts, and iframes as data URIs
  - Supports cookies for authenticated archiving
  - Configurable via MONOLITH_ENABLED, MONOLITH_PATH, etc.

- Add MHTML export via Chrome CDP (complete.mhtml)
  - Browser-rendered archive with all resources bundled
  - Uses existing headless Chrome infrastructure

- Add screenshot and PDF generation
  - Dockerfile now includes Chromium
  - Enabled by default in Docker (SCREENSHOT_ENABLED, PDF_ENABLED)

- Update preview UI to prioritize complete.html
  - Falls back: complete.html > view.html > raw.html
  - Shows preview type label (Full Archive/With Banner/Original)

- Add new artifact types: ViewHtml, CompleteHtml, Mhtml

- Update config.example.toml with all new options

This addresses the known gap of HTML archives lacking styling by providing multiple archival formats for different use cases.