### PR TITLE
Evaluate shadcn UI integration feasibility

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,38 +1,45 @@
-/* Discourse Link Archiver - Discourse-Inspired Theme */
+/* Discourse Link Archiver - shadcn/ui Lyra Theme (Zinc + Pink) */
+
+/* Import Inter font */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 :root {
-    /* Discourse-inspired color palette */
-    --primary: #0088cc;
-    --primary-hover: #006699;
-    --primary-low: rgba(0, 136, 204, 0.1);
+    /* shadcn Lyra - Pink accent color */
+    --primary: #ec4899;
+    --primary-hover: #db2777;
+    --primary-low: rgba(236, 72, 153, 0.1);
     --secondary: #ffffff;
-    --tertiary: #0088cc;
-    --quaternary: #e45735;
-    --header-bg: #222222;
-    --header-primary: #ffffff;
-    --highlight: #ffffb3;
-    --danger: #e45735;
-    --success: #009900;
-    --warning: #ffb300;
-    --love: #fa6c8d;
+    --tertiary: #ec4899;
+    --quaternary: #ef4444;
+    --header-bg: #18181b;
+    --header-primary: #fafafa;
+    --highlight: #fef3c7;
+    --danger: #ef4444;
+    --danger-fg: #dc2626;
+    --success: #22c55e;
+    --success-fg: #16a34a;
+    --warning: #f59e0b;
+    --warning-fg: #d97706;
+    --love: #ec4899;
 
-    /* Text colors */
-    --text-primary: #222222;
-    --text-secondary: #919191;
-    --text-muted: #999999;
+    /* Zinc palette - Text colors */
+    --text-primary: #18181b;
+    --text-secondary: #52525b;
+    --text-muted: #71717a;
 
-    /* Background colors */
+    /* Zinc palette - Background colors */
     --bg-primary: #ffffff;
-    --bg-secondary: #f8f8f8;
-    --bg-tertiary: #eeeeee;
+    --bg-secondary: #fafafa;
+    --bg-tertiary: #f4f4f5;
 
-    /* Border colors */
-    --border-color: #e9e9e9;
-    --border-dark: #cccccc;
+    /* Zinc palette - Border colors */
+    --border-color: #e4e4e7;
+    --border-dark: #d4d4d8;
 
-    /* Shadows */
-    --box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-    --box-shadow-hover: 0 2px 5px rgba(0, 0, 0, 0.15);
+    /* Shadows - More subtle, modern */
+    --box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+    --box-shadow-hover: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+    --box-shadow-focus: 0 0 0 3px rgba(236, 72, 153, 0.1);
 
     /* Spacing */
     --spacing-xs: 0.25rem;
@@ -41,8 +48,8 @@
     --spacing-lg: 1.5rem;
     --spacing-xl: 2rem;
 
-    /* Font */
-    --font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Arial, sans-serif;
+    /* Font - Inter */
+    --font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     --font-size-xs: 0.75rem;
     --font-size-sm: 0.875rem;
     --font-size-base: 1rem;
@@ -50,38 +57,42 @@
     --font-size-xl: 1.25rem;
     --font-size-2xl: 1.5rem;
 
-    /* Border radius */
-    --radius-sm: 3px;
-    --radius-md: 5px;
-    --radius-lg: 8px;
+    /* Border radius - None (sharp corners) */
+    --radius-sm: 0px;
+    --radius-md: 0px;
+    --radius-lg: 0px;
 }
 
-/* Dark mode */
+/* Dark mode - Zinc palette */
 [data-theme="dark"] {
-    --primary: #4db8ff;
-    --primary-hover: #80ccff;
-    --primary-low: rgba(77, 184, 255, 0.15);
-    --secondary: #1e1e1e;
-    --header-bg: #111111;
-    --header-primary: #dddddd;
+    --primary: #f472b6;
+    --primary-hover: #ec4899;
+    --primary-low: rgba(244, 114, 182, 0.15);
+    --secondary: #09090b;
+    --header-bg: #09090b;
+    --header-primary: #fafafa;
 
-    --text-primary: #dddddd;
-    --text-secondary: #aaaaaa;
-    --text-muted: #888888;
+    --text-primary: #fafafa;
+    --text-secondary: #a1a1aa;
+    --text-muted: #71717a;
 
-    --bg-primary: #1e1e1e;
-    --bg-secondary: #252525;
-    --bg-tertiary: #2d2d2d;
+    --bg-primary: #09090b;
+    --bg-secondary: #18181b;
+    --bg-tertiary: #27272a;
 
-    --border-color: #404040;
-    --border-dark: #555555;
+    --border-color: #27272a;
+    --border-dark: #3f3f46;
 
-    --box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
-    --box-shadow-hover: 0 2px 5px rgba(0, 0, 0, 0.4);
+    --box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3), 0 1px 2px -1px rgba(0, 0, 0, 0.3);
+    --box-shadow-hover: 0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -2px rgba(0, 0, 0, 0.4);
+    --box-shadow-focus: 0 0 0 3px rgba(244, 114, 182, 0.2);
 
-    --danger: #ff6b4a;
-    --success: #32cd32;
-    --warning: #ffcc00;
+    --danger: #f87171;
+    --danger-fg: #ef4444;
+    --success: #4ade80;
+    --success-fg: #22c55e;
+    --warning: #fbbf24;
+    --warning-fg: #f59e0b;
 }
 
 /* Base styles */
@@ -132,7 +143,7 @@ p {
 a {
     color: var(--primary);
     text-decoration: none;
-    transition: color 0.15s ease;
+    transition: color 0.2s ease;
 }
 
 a:hover {
@@ -143,7 +154,7 @@ a:hover {
 /* Header */
 header {
     background-color: var(--header-bg);
-    box-shadow: var(--box-shadow);
+    border-bottom: 1px solid var(--border-color);
     position: sticky;
     top: 0;
     z-index: 100;
@@ -160,7 +171,7 @@ header nav {
     justify-content: space-between;
     max-width: 1140px;
     margin: 0 auto;
-    padding: var(--spacing-sm) var(--spacing-md);
+    padding: var(--spacing-md);
 }
 
 header nav ul {
@@ -177,8 +188,7 @@ header nav a {
     font-size: var(--font-size-sm);
     font-weight: 500;
     padding: var(--spacing-xs) var(--spacing-sm);
-    border-radius: var(--radius-sm);
-    transition: background-color 0.15s ease, color 0.15s ease;
+    transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 header nav a:hover {
@@ -199,18 +209,17 @@ header nav li a strong {
     padding: var(--spacing-xs) var(--spacing-sm);
     font-size: var(--font-size-sm);
     cursor: pointer;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.2);
     background: transparent;
     color: var(--header-primary);
-    border-radius: var(--radius-sm);
     margin: 0;
-    transition: background-color 0.15s ease, border-color 0.15s ease;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
 .theme-toggle:hover,
 .nsfw-toggle:hover {
     background-color: rgba(255, 255, 255, 0.1);
-    border-color: rgba(255, 255, 255, 0.5);
+    border-color: rgba(255, 255, 255, 0.3);
 }
 
 .nsfw-toggle.active {
@@ -265,9 +274,8 @@ button,
     color: white;
     background-color: var(--primary);
     border: none;
-    border-radius: var(--radius-sm);
     cursor: pointer;
-    transition: background-color 0.15s ease, box-shadow 0.15s ease;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 button:hover,
@@ -278,20 +286,21 @@ button:hover,
 
 button:focus,
 .btn:focus {
-    outline: 2px solid var(--primary);
-    outline-offset: 2px;
+    outline: none;
+    box-shadow: var(--box-shadow-focus);
 }
 
 button.outline,
 .btn.outline {
     background-color: transparent;
     color: var(--primary);
-    border: 1px solid var(--primary);
+    border: 1px solid var(--border-color);
 }
 
 button.outline:hover,
 .btn.outline:hover {
     background-color: var(--primary-low);
+    border-color: var(--primary);
 }
 
 /* Forms */
@@ -304,9 +313,8 @@ select {
     font-size: var(--font-size-base);
     color: var(--text-primary);
     background-color: var(--bg-primary);
-    border: 1px solid var(--border-dark);
-    border-radius: var(--radius-sm);
-    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    border: 1px solid var(--border-color);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 input:focus,
@@ -314,7 +322,7 @@ textarea:focus,
 select:focus {
     outline: none;
     border-color: var(--primary);
-    box-shadow: 0 0 0 3px var(--primary-low);
+    box-shadow: var(--box-shadow-focus);
 }
 
 input[type="search"] {
@@ -325,6 +333,7 @@ label {
     display: block;
     margin-bottom: var(--spacing-xs);
     font-weight: 500;
+    font-size: var(--font-size-sm);
     color: var(--text-primary);
 }
 
@@ -365,6 +374,7 @@ th {
     font-weight: 600;
     background-color: var(--bg-secondary);
     color: var(--text-primary);
+    font-size: var(--font-size-sm);
 }
 
 tr:hover {
@@ -375,10 +385,9 @@ tr:hover {
 .archive-card {
     background-color: var(--bg-primary);
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
     padding: var(--spacing-md);
     margin-bottom: var(--spacing-md);
-    transition: box-shadow 0.15s ease, border-color 0.15s ease;
+    transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .archive-card:hover {
@@ -444,17 +453,17 @@ tr:hover {
 
 /* Status badges */
 .status-complete {
-    color: var(--success);
+    color: var(--success-fg);
     font-weight: 500;
 }
 
 .status-pending {
-    color: var(--warning);
+    color: var(--warning-fg);
     font-weight: 500;
 }
 
 .status-failed {
-    color: var(--danger);
+    color: var(--danger-fg);
     font-weight: 500;
 }
 
@@ -474,11 +483,10 @@ tr:hover {
     padding: 2px var(--spacing-sm);
     font-size: var(--font-size-xs);
     font-weight: 500;
-    border-radius: var(--radius-sm);
     background-color: var(--bg-tertiary);
     color: var(--text-secondary);
     text-decoration: none;
-    transition: background-color 0.15s ease, color 0.15s ease;
+    transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .domain-badge:hover {
@@ -495,7 +503,6 @@ tr:hover {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    border-radius: var(--radius-sm);
 }
 
 .media-type-video {
@@ -523,7 +530,6 @@ tr:hover {
     background-color: var(--danger);
     color: white;
     padding: 2px var(--spacing-sm);
-    border-radius: var(--radius-sm);
     font-size: var(--font-size-xs);
     font-weight: 600;
     margin-left: var(--spacing-xs);
@@ -531,18 +537,17 @@ tr:hover {
 }
 
 .nsfw-warning {
-    background-color: #fff3cd;
-    border: 1px solid #ffc107;
-    color: #664d03;
+    background-color: #fef3c7;
+    border: 1px solid var(--warning);
+    color: #92400e;
     padding: var(--spacing-md);
-    border-radius: var(--radius-md);
     margin-bottom: var(--spacing-md);
 }
 
 [data-theme="dark"] .nsfw-warning {
-    background-color: #332701;
-    border-color: #ffc107;
-    color: #ffc107;
+    background-color: #451a03;
+    border-color: var(--warning);
+    color: #fbbf24;
 }
 
 /* NSFW hidden message - shown only when filter is active on NSFW content */
@@ -552,7 +557,6 @@ tr:hover {
     padding: var(--spacing-xl);
     background-color: var(--bg-secondary);
     border: 2px dashed var(--border-dark);
-    border-radius: var(--radius-md);
     margin: var(--spacing-lg) 0;
 }
 
@@ -575,7 +579,6 @@ body.nsfw-hidden [data-nsfw-hidden="true"] {
 article {
     background-color: var(--bg-primary);
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
     padding: var(--spacing-lg);
     margin-bottom: var(--spacing-lg);
 }
@@ -601,15 +604,15 @@ article section h2 {
 /* Success and error states */
 article.success,
 .success-message {
-    background-color: rgba(0, 153, 0, 0.1);
+    background-color: rgba(34, 197, 94, 0.1);
     border-color: var(--success);
 }
 
 article.error,
 .error-message {
-    background-color: rgba(228, 87, 53, 0.1);
+    background-color: rgba(239, 68, 68, 0.1);
     border-color: var(--danger);
-    color: var(--danger);
+    color: var(--danger-fg);
 }
 
 /* Media container */
@@ -625,7 +628,6 @@ article.error,
     width: 100%;
     padding-bottom: 56.25%; /* 16:9 aspect ratio */
     background-color: #000;
-    border-radius: var(--radius-md);
     overflow: hidden;
 }
 
@@ -642,7 +644,6 @@ article.error,
 .media-container video {
     max-width: 100%;
     width: 100%;
-    border-radius: var(--radius-md);
     background-color: #000;
 }
 
@@ -650,12 +651,10 @@ article.error,
 .media-container audio {
     width: 100%;
     min-height: 54px;
-    border-radius: var(--radius-lg);
 }
 
 .audio-wrapper {
     padding: var(--spacing-sm);
-    border-radius: var(--radius-lg);
     background: var(--bg-secondary);
     border: 1px solid var(--border-color);
 }
@@ -664,7 +663,6 @@ article.error,
 .media-container img {
     max-width: 100%;
     height: auto;
-    border-radius: var(--radius-md);
     display: block;
 }
 
@@ -706,7 +704,6 @@ article.error,
     max-width: 95%;
     max-height: 95%;
     object-fit: contain;
-    border-radius: 0;
 }
 
 /* Media loading/error states */
@@ -718,7 +715,6 @@ article.error,
     justify-content: center;
     min-height: 200px;
     background: var(--bg-tertiary);
-    border-radius: var(--radius-md);
     color: var(--text-muted);
     padding: var(--spacing-md);
 }
@@ -745,11 +741,10 @@ article.error,
     padding: var(--spacing-sm) var(--spacing-md);
     background: var(--bg-secondary);
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-sm);
     text-decoration: none;
     color: var(--text-primary);
     margin-top: var(--spacing-sm);
-    transition: background-color 0.15s ease;
+    transition: background-color 0.2s ease;
 }
 
 .media-download:hover {
@@ -762,7 +757,6 @@ article.error,
     width: 100%;
     height: 180px;
     object-fit: cover;
-    border-radius: var(--radius-sm);
     background-color: var(--bg-tertiary);
 }
 
@@ -803,9 +797,8 @@ article.error,
     min-width: 36px;
     padding: var(--spacing-sm) var(--spacing-md);
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-sm);
     color: var(--text-primary);
-    transition: all 0.15s ease;
+    transition: all 0.2s ease;
 }
 
 .pagination a:hover {
@@ -837,7 +830,6 @@ article.error,
     font-size: var(--font-size-sm);
     overflow-x: auto;
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
 }
 
 .diff-line {
@@ -867,7 +859,6 @@ article.error,
     padding: 0.25rem 0.5rem;
     background-color: var(--bg-tertiary);
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-sm);
     font-family: monospace;
     font-size: 0.75rem;
     color: var(--text-primary);
@@ -894,7 +885,6 @@ article.error,
     display: inline-block;
     padding: 0.125rem 0.5rem;
     font-size: 0.75rem;
-    border-radius: var(--radius-sm);
     background-color: var(--bg-tertiary);
     color: var(--text-muted);
     font-weight: 500;
@@ -908,7 +898,7 @@ article.error,
 }
 
 .diff-added {
-    background-color: rgba(0, 153, 0, 0.15);
+    background-color: rgba(34, 197, 94, 0.15);
 }
 
 .diff-added .diff-symbol {
@@ -916,7 +906,7 @@ article.error,
 }
 
 .diff-removed {
-    background-color: rgba(228, 87, 53, 0.15);
+    background-color: rgba(239, 68, 68, 0.15);
 }
 
 .diff-removed .diff-symbol {
@@ -947,7 +937,6 @@ article.error,
 .comparison-archive {
     padding: var(--spacing-md);
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
     background-color: var(--bg-secondary);
 }
 
@@ -982,7 +971,6 @@ code {
     font-size: 0.9em;
     padding: 2px 6px;
     background-color: var(--bg-tertiary);
-    border-radius: var(--radius-sm);
     color: var(--text-primary);
 }
 
@@ -991,25 +979,23 @@ pre {
     font-size: var(--font-size-sm);
     padding: var(--spacing-md);
     background-color: var(--bg-tertiary);
-    border-radius: var(--radius-md);
     overflow-x: auto;
 }
 
 /* Archive banner (archive.today style) */
 .archive-banner {
-    border: 2px solid #4a90e2;
-    border-radius: 4px;
+    border: 2px solid var(--primary);
     margin: 0;
     padding: 0;
-    background-color: #f8f9fa;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    background-color: var(--bg-secondary);
+    font-family: var(--font-family);
     font-size: 14px;
     line-height: 1.5;
 }
 
 [data-theme="dark"] .archive-banner {
-    background-color: #1a1a1a;
-    border-color: #5a9ff0;
+    background-color: var(--bg-tertiary);
+    border-color: var(--primary);
 }
 
 .archive-banner details {
@@ -1026,13 +1012,13 @@ pre {
     align-items: center;
     gap: 10px;
     user-select: none;
-    background-color: #e8f0f8;
-    border-bottom: 1px solid #4a90e2;
+    background-color: var(--bg-tertiary);
+    border-bottom: 1px solid var(--primary);
 }
 
 [data-theme="dark"] .archive-banner summary {
-    background-color: #2a2a2a;
-    border-bottom-color: #5a9ff0;
+    background-color: var(--bg-secondary);
+    border-bottom-color: var(--primary);
 }
 
 .archive-banner summary::-webkit-details-marker {
@@ -1050,21 +1036,13 @@ pre {
 .archive-banner .banner-text {
     flex: 1;
     font-weight: 500;
-    color: #333;
-}
-
-[data-theme="dark"] .archive-banner .banner-text {
-    color: #e0e0e0;
+    color: var(--text-primary);
 }
 
 .archive-banner .banner-toggle {
     font-size: 12px;
-    color: #666;
+    color: var(--text-muted);
     transition: transform 0.2s;
-}
-
-[data-theme="dark"] .archive-banner .banner-toggle {
-    color: #999;
 }
 
 .archive-banner details[open] .banner-toggle {
@@ -1073,21 +1051,17 @@ pre {
 
 .archive-banner .banner-content {
     padding: 15px;
-    background-color: #ffffff;
+    background-color: var(--bg-primary);
 }
 
 [data-theme="dark"] .archive-banner .banner-content {
-    background-color: #1a1a1a;
+    background-color: var(--bg-secondary);
 }
 
 .archive-banner .banner-row {
     margin-bottom: 10px;
     padding-bottom: 10px;
-    border-bottom: 1px solid #e0e0e0;
-}
-
-[data-theme="dark"] .archive-banner .banner-row {
-    border-bottom-color: #333;
+    border-bottom: 1px solid var(--border-color);
 }
 
 .archive-banner .banner-row:last-child {
@@ -1097,16 +1071,12 @@ pre {
 }
 
 .archive-banner .banner-row strong {
-    color: #333;
+    color: var(--text-primary);
     margin-right: 8px;
 }
 
-[data-theme="dark"] .archive-banner .banner-row strong {
-    color: #e0e0e0;
-}
-
 .archive-banner .banner-row a {
-    color: #4a90e2;
+    color: var(--primary);
     text-decoration: none;
 }
 
@@ -1117,29 +1087,24 @@ pre {
 .archive-banner .banner-links {
     margin-top: 15px;
     padding-top: 15px;
-    border-top: 1px solid #e0e0e0;
+    border-top: 1px solid var(--border-color);
     display: flex;
     gap: 10px;
     flex-wrap: wrap;
 }
 
-[data-theme="dark"] .archive-banner .banner-links {
-    border-top-color: #333;
-}
-
 .archive-banner .banner-link {
     display: inline-block;
     padding: 6px 12px;
-    background-color: #4a90e2;
+    background-color: var(--primary);
     color: white;
-    border-radius: 3px;
     text-decoration: none;
     font-size: 13px;
     transition: background-color 0.2s;
 }
 
 .archive-banner .banner-link:hover {
-    background-color: #357abd;
+    background-color: var(--primary-hover);
     text-decoration: none;
 }
 
@@ -1201,7 +1166,6 @@ pre {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    border-radius: var(--radius-sm);
     background-color: var(--bg-tertiary);
     color: var(--text-secondary);
 }
@@ -1261,7 +1225,6 @@ pre {
     margin-top: var(--spacing-md);
     padding: var(--spacing-sm) var(--spacing-md);
     background-color: var(--bg-secondary);
-    border-radius: var(--radius-sm);
     font-size: var(--font-size-sm);
 }
 
@@ -1272,7 +1235,6 @@ pre {
 
 .embedded-preview details {
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
     overflow: hidden;
 }
 
@@ -1336,7 +1298,6 @@ pre {
 .capture-item {
     padding: var(--spacing-md);
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
     background-color: var(--bg-secondary);
     text-align: center;
 }
@@ -1352,7 +1313,6 @@ pre {
 .screenshot-preview {
     max-width: 100%;
     max-height: 300px;
-    border-radius: var(--radius-sm);
     border: 1px solid var(--border-color);
     cursor: pointer;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -1370,7 +1330,6 @@ pre {
     gap: var(--spacing-sm);
     padding: var(--spacing-md);
     background-color: var(--bg-tertiary);
-    border-radius: var(--radius-md);
     color: var(--text-primary);
     text-decoration: none;
     transition: background-color 0.15s ease;
@@ -1395,7 +1354,6 @@ pre {
 .captures-missing {
     background-color: var(--bg-secondary);
     padding: var(--spacing-md);
-    border-radius: var(--radius-md);
 }
 
 .captures-note {
@@ -1437,7 +1395,6 @@ pre {
 
 .content-text-section details {
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
     overflow: hidden;
 }
 
@@ -1477,7 +1434,6 @@ pre {
 
 .archive-jobs details {
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
     overflow: hidden;
 }
 
@@ -1540,7 +1496,6 @@ pre {
     color: var(--text-muted);
     background: var(--bg-tertiary);
     padding: 2px 4px;
-    border-radius: var(--radius-sm);
 }
 
 /* Responsive adjustments */


### PR DESCRIPTION
Complete visual overhaul of the UI to match shadcn/ui Lyra aesthetic:

- Color palette: Migrated from Discourse blue to zinc neutrals with pink (#ec4899) accent
- Typography: Replaced system fonts with Inter (Google Fonts)
- Border radius: Removed all rounded corners (set to 0px) for sharp, modern look
- Shadows: Updated to more subtle, modern box-shadow values
- Dark mode: Fully refreshed with proper zinc palette (zinc-950 to zinc-50)
- Focus states: Added pink accent ring on form inputs and buttons
- Component refinement: Cleaner borders, better contrast, improved hover states

All changes are pure CSS - no architectural changes required. The design works seamlessly in both light and dark modes.