### PR TITLE
Fix monolith archiver issues

### DIFF
--- a/src/archiver/monolith.rs
+++ b/src/archiver/monolith.rs
@@ -92,6 +92,20 @@ pub async fn create_complete_html(
         cmd.arg("-j");
     }
 
+    // Exclude archive sites from asset fetching to avoid recursive archive references
+    // Web Archive domains
+    cmd.arg("-B").arg("web.archive.org");
+    cmd.arg("-B").arg("archive.org");
+
+    // Archive.today and its many aliases/mirrors
+    cmd.arg("-B").arg("archive.today");
+    cmd.arg("-B").arg("archive.is");
+    cmd.arg("-B").arg("archive.ph");
+    cmd.arg("-B").arg("archive.fo");
+    cmd.arg("-B").arg("archive.li");
+    cmd.arg("-B").arg("archive.md");
+    cmd.arg("-B").arg("archive.vn");
+
     // Set a reasonable timeout for network requests (in seconds)
     cmd.arg("-t").arg("30");
 


### PR DESCRIPTION
Monolith v3.0+ inverted flags from inclusion to exclusion:
- Removed obsolete -s (include CSS) - CSS now included by default
- Removed obsolete -i (include images) - images now included by default
- Removed obsolete -f (include fonts) - fonts now included by default
- Removed obsolete -F (include iframes) - frames now included by default
- Inverted -j flag logic: now excludes JS when config.include_js is false

Fixes 'unexpected argument -s' errors when archiving with monolith.