### PR TITLE
Fix multipart upload functionality

### DIFF
--- a/src/archiver/screenshot.rs
+++ b/src/archiver/screenshot.rs
@@ -22,8 +22,8 @@ use tracing::{debug, error, info, warn};
 use url::Url;
 
 use crate::chromium_profile::chromium_user_data_and_profile_from_spec;
-use crate::fs_utils::copy_dir_best_effort;
 use crate::constants::ARCHIVAL_USER_AGENT;
+use crate::fs_utils::copy_dir_best_effort;
 
 /// Default viewport width in pixels.
 pub const DEFAULT_VIEWPORT_WIDTH: u32 = 1280;

--- a/src/web/templates.rs
+++ b/src/web/templates.rs
@@ -615,10 +615,12 @@ pub fn render_archive_detail(
         ));
     }
 
-    let thumb_key = archive
-        .s3_key_thumb
-        .as_deref()
-        .or_else(|| artifacts.iter().find(|a| a.kind == "thumb").map(|a| a.s3_key.as_str()));
+    let thumb_key = archive.s3_key_thumb.as_deref().or_else(|| {
+        artifacts
+            .iter()
+            .find(|a| a.kind == "thumb")
+            .map(|a| a.s3_key.as_str())
+    });
 
     let primary_key_opt = archive.s3_key_primary.as_deref();
     let is_html_archive = primary_key_opt
@@ -652,11 +654,8 @@ pub fn render_archive_detail(
     // Fallback: if primary media wasn't rendered, show first video artifact inline
     if primary_key_opt.is_none() && !is_html_archive {
         if let Some(video_artifact) = artifacts.iter().find(|a| a.kind == "video") {
-            let download_name = suggested_download_filename(
-                &link.domain,
-                archive.id,
-                &video_artifact.s3_key,
-            );
+            let download_name =
+                suggested_download_filename(&link.domain, archive.id, &video_artifact.s3_key);
             content.push_str("<section><h2>Media</h2>");
             content.push_str(&render_media_player(
                 &video_artifact.s3_key,


### PR DESCRIPTION
AsyncReadExt::read() may return fewer bytes than the buffer size even when more data is available. This caused 23MB files to be split into 12 small parts (~2MB each) instead of 5 proper parts (5MB each), resulting in S3's EntityTooSmall error since parts must be at least 5MB.

Fix by looping until the buffer is completely filled or EOF is reached.