### PR TITLE
Prevent archiving links to current site

### DIFF
--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -616,3 +616,15 @@ pub struct CommentWithAuthor {
     pub edit_count: i64,
     pub helpful_count: i64,
 }
+
+/// An excluded domain that should not be archived.
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct ExcludedDomain {
+    pub id: i64,
+    pub domain: String,
+    pub reason: String,
+    pub is_active: bool,
+    pub created_at: String,
+    pub created_by_user_id: Option<i64>,
+    pub updated_at: String,
+}

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -64,6 +64,22 @@ pub fn router() -> Router<AppState> {
             "/admin/user/reset-password",
             post(auth::admin_reset_password),
         )
+        .route(
+            "/admin/excluded-domains",
+            get(auth::admin_excluded_domains_page),
+        )
+        .route(
+            "/admin/excluded-domains/add",
+            post(auth::admin_add_excluded_domain),
+        )
+        .route(
+            "/admin/excluded-domains/toggle",
+            post(auth::admin_toggle_excluded_domain),
+        )
+        .route(
+            "/admin/excluded-domains/delete",
+            post(auth::admin_delete_excluded_domain),
+        )
         .route("/archives/failed", get(recent_failed_archives))
         .route("/archives/all", get(recent_all_archives))
         .route("/search", get(search))

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -16,10 +16,19 @@
     --highlight: #fef3c7;
     --danger: #ef4444;
     --danger-fg: #dc2626;
+    --error-bg: #fee2e2;
+    --error-border: #fca5a5;
+    --error-text: #991b1b;
     --success: #22c55e;
     --success-fg: #16a34a;
+    --success-bg: #d1fae5;
+    --success-border: #6ee7b7;
+    --success-text: #065f46;
     --warning: #f59e0b;
     --warning-fg: #d97706;
+    --warning-bg: #fef3c7;
+    --warning-border: #fcd34d;
+    --warning-text: #92400e;
     --love: #ec4899;
 
     /* Zinc palette - Text colors */
@@ -89,10 +98,19 @@
 
     --danger: #f87171;
     --danger-fg: #ef4444;
+    --error-bg: #7f1d1d;
+    --error-border: #991b1b;
+    --error-text: #fecaca;
     --success: #4ade80;
     --success-fg: #22c55e;
+    --success-bg: #064e3b;
+    --success-border: #047857;
+    --success-text: #86efac;
     --warning: #fbbf24;
     --warning-fg: #f59e0b;
+    --warning-bg: #78350f;
+    --warning-border: #b45309;
+    --warning-text: #fcd34d;
 }
 
 /* Base styles */

--- a/tests/comment_test.rs
+++ b/tests/comment_test.rs
@@ -4,9 +4,8 @@ use discourse_link_archiver::auth::hash_password;
 use discourse_link_archiver::db::{
     add_comment_reaction, can_user_edit_comment, create_comment, create_comment_reply,
     create_pending_archive, create_user, get_comment_edit_history, get_comment_reaction_count,
-    get_comment_with_author, get_comments_for_archive, has_user_reacted, insert_link,
-    pin_comment, remove_comment_reaction, soft_delete_comment, unpin_comment, update_comment,
-    Database, NewLink,
+    get_comment_with_author, get_comments_for_archive, has_user_reacted, insert_link, pin_comment,
+    remove_comment_reaction, soft_delete_comment, unpin_comment, update_comment, Database, NewLink,
 };
 use tempfile::TempDir;
 
@@ -84,9 +83,10 @@ async fn test_create_comment_reply() {
         .unwrap();
 
     // Create reply
-    let reply_id = create_comment_reply(db.pool(), archive_id, user_id2, parent_id, "Reply comment")
-        .await
-        .expect("Failed to create reply");
+    let reply_id =
+        create_comment_reply(db.pool(), archive_id, user_id2, parent_id, "Reply comment")
+            .await
+            .expect("Failed to create reply");
 
     assert!(reply_id > 0);
 
@@ -319,9 +319,7 @@ async fn test_pinned_comments_appear_first() {
         .unwrap();
 
     // Pin the second comment
-    pin_comment(db.pool(), comment2_id, admin_id)
-        .await
-        .unwrap();
+    pin_comment(db.pool(), comment2_id, admin_id).await.unwrap();
 
     // Retrieve comments
     let comments = get_comments_for_archive(db.pool(), archive_id)
@@ -525,26 +523,15 @@ async fn test_nested_comment_threads() {
         .unwrap();
 
     // Create a reply
-    let reply1_id = create_comment_reply(
-        db.pool(),
-        archive_id,
-        user_id,
-        top_level_id,
-        "First reply",
-    )
-    .await
-    .unwrap();
+    let reply1_id =
+        create_comment_reply(db.pool(), archive_id, user_id, top_level_id, "First reply")
+            .await
+            .unwrap();
 
     // Create a nested reply
-    let reply2_id = create_comment_reply(
-        db.pool(),
-        archive_id,
-        user_id,
-        reply1_id,
-        "Nested reply",
-    )
-    .await
-    .unwrap();
+    let reply2_id = create_comment_reply(db.pool(), archive_id, user_id, reply1_id, "Nested reply")
+        .await
+        .unwrap();
 
     // Verify structure
     let top_comment = get_comment_with_author(db.pool(), top_level_id)


### PR DESCRIPTION
- Add HTTP header (X-No-Archive: 1) to all responses
- Add meta tags (robots: noarchive, x-no-archive) to all HTML pages
- Support allowArchive=1 query parameter to bypass prevention signals
- Create excluded_domains database table for managing blocked domains
- Add admin interface to manage excluded domains (add, toggle, delete)
- Automatically exclude app's own domains on startup (from web_host, TLS domains, and RSS forum domain)
- Implement archive prevention check in archiver worker before downloading
- Fetch URLs and check for prevention signals (header + meta tags) with 10s timeout
- Improve dark mode styling for all alert/notification boxes:
  - Add CSS variables for success, warning, and error states
  - Override colors for dark mode (--success-bg, --success-border, --success-text, etc)
  - Fix account creation prompt to use dynamic colors for dark mode compatibility
  - Update notification styling to use CSS variables instead of hardcoded colors

This prevents the webapp from accidentally archiving itself or other instances, and provides multiple redundant signals (HTTP header + meta tags) that archivers can check before saving content.