### PR TITLE
Add creator attribution link to layout footer

### DIFF
--- a/src/components/layout.rs
+++ b/src/components/layout.rs
@@ -182,6 +182,8 @@ impl<'a> BaseLayout<'a> {
                     a href="/feed.rss" { "RSS" }
                     " | "
                     a href="/feed.atom" { "Atom" }
+                    " | Created by "
+                    a href="https://xk.io" target="_blank" rel="noopener noreferrer" { "Max Kaye" }
                 }
             }
         }


### PR DESCRIPTION
## Summary
Added a creator attribution link in the footer of the base layout, crediting Max Kaye with a link to their website.

## Changes
- Added "Created by" text followed by a link to https://xk.io in the footer
- Link opens in a new tab with `target="_blank"` and includes security attributes (`rel="noopener noreferrer"`)
- Positioned after the existing RSS and Atom feed links with a pipe separator

## Implementation Details
The attribution is added to the footer navigation section of the BaseLayout component, maintaining consistency with the existing feed link styling and structure.

https://claude.ai/code/session_012Tf7cNinB6ffJxswsr3Xy3