### PR TITLE
Use configurable public_base_url for feed generation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -71,6 +71,7 @@ pub struct Config {
     // Web Server
     pub web_host: String,
     pub web_port: u16,
+    pub public_base_url: String,
 
     // TLS / Let's Encrypt
     pub tls_enabled: bool,
@@ -244,6 +245,7 @@ pub struct ArchiveConfig {
 pub struct WebConfig {
     pub host: Option<String>,
     pub port: Option<u16>,
+    pub public_base_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -541,6 +543,11 @@ impl Config {
             // Web Server
             web_host: get_string("WEB_HOST", fc.web.host, "0.0.0.0"),
             web_port: parse_env_u16("WEB_PORT", fc.web.port.unwrap_or(8080))?,
+            public_base_url: get_string(
+                "PUBLIC_BASE_URL",
+                fc.web.public_base_url,
+                "https://cf-archiver.xk.io",
+            ),
 
             // TLS / Let's Encrypt
             tls_enabled: parse_env_bool("TLS_ENABLED", fc.tls.enabled.unwrap_or(false))?,
@@ -1005,6 +1012,7 @@ impl Config {
             archive_quote_only_links: false,
             web_host: "0.0.0.0".to_string(),
             web_port: 8080,
+            public_base_url: "https://cf-archiver.xk.io".to_string(),
             tls_enabled: false,
             tls_domains: vec![],
             tls_contact_email: None,

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -2447,10 +2447,9 @@ async fn feed_rss(State(state): State<AppState>, Query(params): Query<FeedParams
         }
     };
 
-    // Determine base URL from config or default
-    let base_url = format!("http://{}:{}", state.config.web_host, state.config.web_port);
+    let base_url = &state.config.public_base_url;
 
-    let rss = feeds::generate_rss(&archives, &base_url);
+    let rss = feeds::generate_rss(&archives, base_url);
 
     (
         StatusCode::OK,
@@ -2478,10 +2477,9 @@ async fn feed_atom(State(state): State<AppState>, Query(params): Query<FeedParam
         }
     };
 
-    // Determine base URL from config or default
-    let base_url = format!("http://{}:{}", state.config.web_host, state.config.web_port);
+    let base_url = &state.config.public_base_url;
 
-    let atom = feeds::generate_atom(&archives, &base_url);
+    let atom = feeds::generate_atom(&archives, base_url);
 
     (
         StatusCode::OK,


### PR DESCRIPTION
## Summary
Refactored feed generation to use a configurable `public_base_url` from the application config instead of dynamically constructing the base URL from `web_host` and `web_port`.

## Key Changes
- Added `public_base_url` field to the `Config` struct with a default value of `https://cf-archiver.xk.io`
- Added `public_base_url` field to the `WebConfig` struct to support configuration via TOML and environment variables
- Updated `feed_rss()` and `feed_atom()` route handlers to use `state.config.public_base_url` instead of constructing the URL from host and port
- Removed the dynamic URL construction logic (`format!("http://{}:{}", state.config.web_host, state.config.web_port)`) from both feed endpoints

## Implementation Details
- The `public_base_url` can be configured via the `PUBLIC_BASE_URL` environment variable or the `[web]` section of the TOML config file
- Defaults to `https://cf-archiver.xk.io` if not explicitly configured
- This allows the public-facing URL to differ from the internal web server binding address, which is useful for deployments behind reverse proxies or when the service is accessed via a different domain/protocol than the internal binding

https://claude.ai/code/session_01DC4STKCFaaCPymPifCHn9M