### PR TITLE
Add TikTok subtitle CDN expiration fallback with metadata re-fetch

### DIFF
--- a/src/db/backfill.rs
+++ b/src/db/backfill.rs
@@ -82,7 +82,7 @@ pub const METRICS_BACKFILL_VERSION: i64 = 1;
 ///   header → 403, language code mismatch `en` vs `eng-US`).
 /// - v2: Referer/Origin headers added, language wildcard `en.*` to match `eng-US`. Reset
 ///   all prior markers so affected archives are retried.
-pub const SUBTITLE_BACKFILL_VERSION: i64 = 2;
+pub const SUBTITLE_BACKFILL_VERSION: i64 = 3;
 
 /// Configuration for the backfill worker.
 pub struct BackfillConfig {
@@ -295,9 +295,11 @@ pub async fn run_tiktok_subtitle_backfill_worker(
         let batch_size = batch.len();
         let mut batch_success = 0u64;
 
-        for (archive_id, meta_s3_key) in batch {
+        for (archive_id, meta_s3_key, original_url) in batch {
             let (count, should_mark) =
-                match backfill_tiktok_subtitles(&db, &s3, archive_id, &meta_s3_key).await {
+                match backfill_tiktok_subtitles(&db, &s3, archive_id, &meta_s3_key, &original_url)
+                    .await
+                {
                     Ok((count, should_mark)) => {
                         if count > 0 {
                             batch_success += 1;
@@ -391,6 +393,7 @@ async fn backfill_tiktok_subtitles(
     s3: &S3Client,
     archive_id: i64,
     meta_s3_key: &str,
+    original_url: &str,
 ) -> Result<(usize, bool)> {
     // Returns (count, should_mark_attempted)
     use crate::archiver::process_subtitle_files;
@@ -457,13 +460,79 @@ async fn backfill_tiktok_subtitles(
             }
         };
 
+        // If CDN URLs from saved meta.json have expired (common for TikTok time-limited URLs),
+        // fall back to re-fetching fresh metadata via yt-dlp for new CDN URLs.
+        if filenames.is_empty() && has_english {
+            warn!(
+                archive_id,
+                original_url,
+                "TikTok subtitle CDN URLs appear expired; re-fetching fresh metadata via yt-dlp"
+            );
+            use crate::archiver::{ytdlp, CookieOptions};
+            let empty_cookies = CookieOptions::default();
+            match ytdlp::get_tiktok_metadata(original_url, &empty_cookies).await {
+                Ok(fresh_meta) => {
+                    let fresh_subtitles = extract_subtitle_info(&fresh_meta.json);
+                    let fresh_has_english = fresh_subtitles
+                        .iter()
+                        .any(|s| s.language_code.starts_with("eng-"));
+                    debug!(
+                        archive_id,
+                        subtitle_count = fresh_subtitles.len(),
+                        fresh_has_english,
+                        "Re-fetched TikTok metadata for subtitle retry"
+                    );
+                    if fresh_has_english {
+                        match download_tiktok_subtitles(&fresh_subtitles, &work_dir, true).await {
+                            Ok(fresh_files) if !fresh_files.is_empty() => {
+                                let count = fresh_files.len();
+                                let s3_prefix =
+                                    meta_s3_key.trim_end_matches("meta.json").to_string();
+                                process_subtitle_files(
+                                    db,
+                                    s3,
+                                    archive_id,
+                                    &fresh_files,
+                                    &work_dir,
+                                    &s3_prefix,
+                                )
+                                .await;
+                                let _ = std::fs::remove_dir_all(&work_dir);
+                                return Ok((count, true, ""));
+                            }
+                            Ok(_) => {
+                                warn!(
+                                    archive_id,
+                                    "Fresh TikTok subtitle download also failed (CDN blocked or subtitles removed)"
+                                );
+                            }
+                            Err(e) => {
+                                warn!(archive_id, error = %e, "Error downloading fresh TikTok subtitles");
+                            }
+                        }
+                    } else {
+                        debug!(archive_id, "Fresh TikTok metadata has no English subtitles");
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        archive_id,
+                        error = %e,
+                        "Failed to re-fetch TikTok metadata for subtitle retry"
+                    );
+                }
+            }
+            let _ = std::fs::remove_dir_all(&work_dir);
+            return Ok((0, true, "subtitle CDN URLs expired and re-fetch failed"));
+        }
+
         if filenames.is_empty() {
             debug!(
                 archive_id,
                 has_english, "No English subtitles downloaded (subtitles exist in other languages)"
             );
             let _ = std::fs::remove_dir_all(&work_dir);
-            return Ok((0, true, "no English subtitles available")); // Mark as attempted - no English subtitles
+            return Ok((0, true, "no English subtitles available")); // Mark as attempted - no English subs
         }
 
         let count = filenames.len();

--- a/src/db/backfill.rs
+++ b/src/db/backfill.rs
@@ -82,6 +82,8 @@ pub const METRICS_BACKFILL_VERSION: i64 = 1;
 ///   header → 403, language code mismatch `en` vs `eng-US`).
 /// - v2: Referer/Origin headers added, language wildcard `en.*` to match `eng-US`. Reset
 ///   all prior markers so affected archives are retried.
+/// - v3: Re-fetch fresh metadata via yt-dlp when saved CDN URLs have expired (common for
+///   TikTok time-limited subtitle URLs). Reset all prior markers so affected archives retry.
 pub const SUBTITLE_BACKFILL_VERSION: i64 = 3;
 
 /// Configuration for the backfill worker.
@@ -386,8 +388,8 @@ pub async fn run_tiktok_subtitle_backfill_worker(
 
 /// Backfill subtitles for a single TikTok archive.
 ///
-/// Returns the number of subtitle files downloaded, or 0 if none found/available.
-/// Returns -1 (cast to usize wraps) when we've attempted but found nothing (for marking).
+/// Returns `(count, should_mark_attempted)` where count is files downloaded and
+/// should_mark_attempted indicates whether to record this as a completed attempt.
 async fn backfill_tiktok_subtitles(
     db: &Database,
     s3: &S3Client,
@@ -450,6 +452,7 @@ async fn backfill_tiktok_subtitles(
         let work_dir =
             std::env::temp_dir().join(format!("tiktok-subtitle-backfill-{}", archive_id));
         std::fs::create_dir_all(&work_dir)?;
+        let s3_prefix = meta_s3_key.trim_end_matches("meta.json").to_string();
 
         // Download subtitles (English only for now)
         let filenames = match download_tiktok_subtitles(&subtitles, &work_dir, true).await {
@@ -486,8 +489,6 @@ async fn backfill_tiktok_subtitles(
                         match download_tiktok_subtitles(&fresh_subtitles, &work_dir, true).await {
                             Ok(fresh_files) if !fresh_files.is_empty() => {
                                 let count = fresh_files.len();
-                                let s3_prefix =
-                                    meta_s3_key.trim_end_matches("meta.json").to_string();
                                 process_subtitle_files(
                                     db,
                                     s3,
@@ -538,8 +539,6 @@ async fn backfill_tiktok_subtitles(
         let count = filenames.len();
 
         // Process and upload subtitle files
-        // Derive s3_prefix from meta_s3_key (strip "meta.json" suffix)
-        let s3_prefix = meta_s3_key.trim_end_matches("meta.json").to_string();
         process_subtitle_files(db, s3, archive_id, &filenames, &work_dir, &s3_prefix).await;
 
         // Clean up

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -3228,8 +3228,8 @@ pub async fn get_tiktok_archives_needing_subtitle_backfill(
     pool: &SqlitePool,
     limit: i64,
     min_version: i64,
-) -> Result<Vec<(i64, String)>> {
-    let results: Vec<(i64, String)> = sqlx::query_as(
+) -> Result<Vec<(i64, String, String)>> {
+    let results: Vec<(i64, String, String)> = sqlx::query_as(
         r"
         SELECT a.id,
             COALESCE(
@@ -3237,7 +3237,8 @@ pub async fn get_tiktok_archives_needing_subtitle_backfill(
                  WHERE aa.archive_id = a.id AND aa.s3_key LIKE '%meta.json'
                  LIMIT 1),
                 'archives/' || a.id || '/meta.json'
-            ) AS meta_s3_key
+            ) AS meta_s3_key,
+            l.normalized_url
         FROM archives a
         JOIN links l ON a.link_id = l.id
         WHERE a.status = 'complete'


### PR DESCRIPTION
## Summary
This PR enhances the TikTok subtitle backfill worker to handle expired CDN URLs by implementing a fallback mechanism that re-fetches fresh metadata via yt-dlp when saved subtitle URLs are no longer accessible.

## Key Changes
- **Version bump**: Incremented `SUBTITLE_BACKFILL_VERSION` from 2 to 3 to trigger reprocessing of affected archives
- **Database query enhancement**: Modified `get_tiktok_archives_needing_subtitle_backfill()` to return the original URL alongside archive ID and S3 key, enabling re-fetching of metadata
- **Fallback logic**: Added detection for expired CDN URLs (when no subtitle files are found despite English subtitles being present in metadata) with automatic re-fetch via yt-dlp
- **Graceful degradation**: When fresh metadata is successfully retrieved, attempts to download subtitles again; if that also fails, marks the attempt as completed with appropriate logging

## Implementation Details
- The fallback mechanism only triggers when `filenames.is_empty() && has_english` is true, indicating the metadata exists but CDN URLs are inaccessible
- Fresh metadata is fetched using empty cookie options to ensure a clean request
- If fresh subtitles are successfully downloaded, they are processed and uploaded to S3 like normal backfill operations
- Comprehensive logging at warn/debug levels tracks each step of the fallback process for observability
- The function signature of `backfill_tiktok_subtitles()` now includes the `original_url` parameter to support re-fetching

https://claude.ai/code/session_01LDqYgY9xKc7RQ3ECx9DDzG